### PR TITLE
Unlock the system through SSH when it boots.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ in the official documentation.
 ### System installation and features
 
 - Custom Debian installer generation with full disk encryption and fully automatic installation.
+- Enter the passphrase through SSH when the server boots, no need to keyboard / monitor.
 - Install packages only from Debian stable (Stretch) or officially maintained repositories (rspamd).
 - Automatic SSL Certificates generation with [letsencrypt](https://letsencrypt.org).
 - Automatic security updates (optional).

--- a/docs/features.md
+++ b/docs/features.md
@@ -39,6 +39,12 @@ encrypted using LUKS, with the passphrase specified in a configuration file.
 This make your server fully secure against physical intrusion, even if your hardware is
 lost or stolen.
 
+You do not have to plug a screen and a keyboard to unlock your server. Once it is booted,
+the server starts a small SSH server to connect, and let you enter the passphrase. The SSH
+server is the excellent [dropbear](https://matt.ucc.asn.au/dropbear/dropbear.html),
+and shares the public key with OpenSSH:
+_You will not have the usual SSH warnings staying the signature has changed_.
+
 ## AppArmor enforcement
 
 All the daemons are carefully configured with an AppArmor profile, in enforce mode. This

--- a/install/playbooks/luks-remote.yml
+++ b/install/playbooks/luks-remote.yml
@@ -1,0 +1,9 @@
+---
+
+# Install a minimal SSH server to remotely unlock the system, via SSH
+- hosts: homebox
+  vars_files:
+    - '{{ playbook_dir }}/../../config/system.yml'
+    - '{{ playbook_dir }}/../../config/defaults.yml'
+  roles:
+    - luks-remote

--- a/install/playbooks/main.yml
+++ b/install/playbooks/main.yml
@@ -5,6 +5,9 @@
 - import_playbook: external-ip.yml
 - import_playbook: system-prepare.yml
 
+# Install dropbear to remotely unlock the system
+- import_playbook: luks-remote.yml
+
 # Install nginx as the default web server,
 # it is needed to obtain certificates with certbot.
 - import_playbook: nginx.yml

--- a/install/playbooks/roles/luks-remote/tasks/main.yml
+++ b/install/playbooks/roles/luks-remote/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+
+- name: Install the required package
+  tags: apt
+  apt:
+    update_cache: true
+    name: '{{ pkg }}'
+    state: present
+  with_items:
+    - busybox
+    - dropbear
+    - dropbear-initramfs
+  loop_control:
+    loop_var: pkg
+
+- name: Copy the ssh public key for authentication
+  copy:
+    src: /root/.ssh/authorized_keys
+    dest: /etc/dropbear-initramfs/authorized_keys
+    remote_src: yes
+
+- name: Set the keys to convert
+  set_fact:
+    keys_convert:
+    - src: ssh_host_ecdsa_key
+      dest: dropbear_ecdsa_host_key
+    - src: ssh_host_rsa_key
+      dest: dropbear_rsa_host_key
+
+- name: Remove dropbear default keys
+  file:
+    path: /etc/dropbear-initramfs/{{ key }}
+    state: absent
+  with_items:
+      - dropbear_ecdsa_host_key
+      - dropbear_rsa_host_key
+      - dropbear_dss_host_key
+  loop_control:
+    loop_var: key
+
+- name: Convert the openssh key already existing for dropbear
+  shell: >-
+    /usr/lib/dropbear/dropbearconvert openssh dropbear
+    /etc/ssh/{{ key.src }} /etc/dropbear-initramfs/{{ key.dest }}
+  with_items:
+    - '{{ keys_convert }}'
+  loop_control:
+    loop_var: key
+
+- name: Convert the openssh key already existing for dropbear
+  shell: >-
+    /usr/lib/dropbear/dropbearconvert openssh dropbear
+    /etc/ssh/{{ key.src }} /etc/dropbear/{{ key.dest }}
+  with_items:
+    - '{{ keys_convert }}'
+  loop_control:
+    loop_var: key
+
+- name: Update initramfs
+  shell: update-initramfs -u


### PR DESCRIPTION
Unlock the system through SSH when it boots, using an embedded dropbear server.
The SSH public keys are shared with the OpenSSH server, which avoids SSH warnings on login.