### PR TITLE
Fixes and improvements, specially IPv6

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -203,7 +203,6 @@ system_default:
 firewall_default:
   fwknop:
     install: false
-    nic: '{{ ansible_default_ipv4.interface | default(ansible_default_ipv6.interface) }}'
     port: random
   ssh:
     - src: any

--- a/install/playbooks/main.yml
+++ b/install/playbooks/main.yml
@@ -12,9 +12,9 @@
 
 # Install fwknop (Single Packet Authorization)
 - import_playbook: fwknop-client.yml
-  when: firewall.fwknop is defined and firewall.fwknop.install
+  when: firewall.fwknop.install
 - import_playbook: fwknop-server.yml
-  when: firewall.fwknop is defined and firewall.fwknop.install
+  when: firewall.fwknop.install
 
 # Install dropbear to remotely unlock the system.
 # Will not do anything if the drive is not encrypted
@@ -49,7 +49,7 @@
 - import_playbook: rspamd.yml
   when: mail.antispam.active
 
-  # Install the web frontend for the antispam system
+# Install the web frontend for the antispam system
 - import_playbook: rspamd-web.yml
   when: mail.antispam.webui.active
 
@@ -126,3 +126,8 @@
 # defined a lot of accounts.
 - import_playbook: import-accounts.yml
   when: mail.import.active and not system.devel
+
+
+
+# Clean up the system before going live
+- import_playbook: system-cleanup.yml

--- a/install/playbooks/roles/certificates/tasks/main.yml
+++ b/install/playbooks/roles/certificates/tasks/main.yml
@@ -181,6 +181,7 @@
     regexp: authenticator = standalone
     replace: authenticator = webroot
 
+# TODO: Remove this part, the certificates are now deployed "standalone"
 - name: Add missing lines when changed from standalone to webroot
   tags: upgrade
   when: renewal_config.changed
@@ -194,8 +195,10 @@
   loop_control:
     loop_var: line
 
-- name: Run the certificate renewal script if needed
-  shell: certbot renew
+# FIXME: Call the custom script for this domain instead
+# - name: Run the certificate renewal script if needed
+#   shell: >-
+#     certbot certonly -d {{ certificate_fqdn }}
 
 # In this direction, we should overwrite the symbolic links,
 # in case the certificates have been renewed

--- a/install/playbooks/roles/certificates/templates/nginx-cert.conf
+++ b/install/playbooks/roles/certificates/templates/nginx-cert.conf
@@ -2,8 +2,10 @@
 # Basic site dedicated to the renewal of the certificate {{ certificate }}
 server {
 
-    # Listen on port 80
+    # Listen on port 80 on IPv4 and IPv6
     listen 80;
+    listen [::]:80;
+
     server_name {{ certificate_fqdn }};
 
     root {{ site_root }};

--- a/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
@@ -3,22 +3,10 @@
 # This is checking that the DNS server has been fully propagated
 - name: Check DNS propagation
   shell: >-
-    host main.{{ network.domain }} {{ server }}
-  with_items:
-    - 8.8.8.8
-    - 8.8.4.4
-    - 1.1.1.1
-  loop_control:
-    loop_var: server
+    host main.{{ network.domain }}
 
 # This is checking that the DNS server has been fully propagated
 - name: Check DNS propagation for backup IP address
   when: network.backup_ip is defined
   shell: >-
-    host backup.{{ network.domain }} {{ server }}
-  with_items:
-    - 8.8.8.8
-    - 8.8.4.4
-    - 1.1.1.1
-  loop_control:
-    loop_var: server
+    host backup.{{ network.domain }}

--- a/install/playbooks/roles/dovecot/templates/conf.d/10-mail.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/10-mail.conf
@@ -123,6 +123,7 @@ namespace inbox {
 # Should shared INBOX be visible as "shared/user" or "shared/user/INBOX"?
 #mail_shared_explicit_inbox = no
 
+{% if mail.virtual_folders.active %}
 namespace {
   prefix = "Search/"
   separator = /
@@ -134,6 +135,7 @@ namespace {
   # List the shared/ namespace only if there are visible shared mailboxes.
   # list = children
 }
+{% endif %}
 
 # System user and group used to access mails. If you use multiple, userdb
 # can override these by returning uid or gid fields. You can use either numbers

--- a/install/playbooks/roles/dovecot/templates/conf.d/15-mailboxes.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/15-mailboxes.conf
@@ -11,11 +11,11 @@
 #   implicitly when it is first accessed. The user can also be automatically
 #   subscribed to the mailbox after creation. The following values are
 #   defined for this setting:
-# 
+#
 #     no        - Never created automatically.
 #     create    - Automatically created, but no automatic subscription.
 #     subscribe - Automatically created and subscribed.
-#  
+#
 # special_use:
 #   A space-separated list of SPECIAL-USE flags (RFC 6154) to use for the
 #   mailbox. There are no validity checks, so you could specify anything
@@ -23,7 +23,7 @@
 #   standard ones specified in the RFC:
 #
 #     \All      - This (virtual) mailbox presents all messages in the
-#                 user's message store. 
+#                 user's message store.
 #     \Archive  - This mailbox is used to archive messages.
 #     \Drafts   - This mailbox is used to hold draft messages.
 #     \Flagged  - This (virtual) mailbox presents all messages in the
@@ -44,6 +44,7 @@
 
 # NOTE: Assumes "namespace inbox" has been defined in 10-mail.conf.
 namespace inbox {
+
   # These mailboxes are widely used and could perhaps be created automatically:
   mailbox Drafts {
     special_use = \Drafts
@@ -66,16 +67,19 @@ namespace inbox {
     special_use = \Archive
     auto = subscribe
   }
+{% if mail.virtual_folders.active %}
+  If you have a virtual "All messages" mailbox:
+  mailbox Search/All {
+    special_use = \All
+    comment = All my messages
+    auto = subscribe
+  }
 
-  # If you have a virtual "All messages" mailbox:
-  #mailbox virtual/All {
-  #  special_use = \All
-  #  comment = All my messages
-  #}
-
-  # If you have a virtual "Flagged" mailbox:
-  #mailbox virtual/Flagged {
-  #  special_use = \Flagged
-  #  comment = All my flagged messages
-  #}
+  If you have a virtual "Flagged" mailbox:
+  mailbox Search/Flagged {
+    special_use = \Flagged
+    comment = All my flagged messages
+    auto = subscribe
+  }
+{% endif %}
 }

--- a/install/playbooks/roles/dovecot/templates/conf.d/90-quota.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/90-quota.conf
@@ -61,9 +61,10 @@ service quota-warning {
 #   dict: Keep quota stored in dictionary (eg. SQL)
 #   maildir: Maildir++ quota
 #   fs: Read-only support for filesystem quota
-
+# NOTE: Do not put a space in quota name, there is a bug in SOGo 3:
+# https://sogo.nu/bugs/view.php?id=1494
 plugin {
-  quota = maildir:User quota
+  quota = maildir:user-quota
   quota_rule = *:storage={{ mail.quota.default }}
 }
 

--- a/install/playbooks/roles/external-ip/tasks/main.yml
+++ b/install/playbooks/roles/external-ip/tasks/main.yml
@@ -47,13 +47,13 @@
     external_ip_type: '{{ (main_ip_type.stdout) }}'
 
 - name: Get the backup IP address
+  when: network.backup_ip != None
   tags: facts
-  when: network.backup_ip is defined
   set_fact:
     backup_ip: '{{ network.backup_ip }}'
 
 - name: Set external IP address type (A or AAAA)
-  when: network.backup_ip is defined
+  when: network.backup_ip != None
   register: backup_ip_type
   shell:
     echo {{ backup_ip }}
@@ -61,6 +61,6 @@
     && echo A || echo AAAA
 
 - name: Set external IP address type (A or AAAA)
-  when: network.backup_ip is defined
+  when: network.backup_ip != None
   set_fact:
     backup_ip_type: '{{ (backup_ip_type.stdout) }}'

--- a/install/playbooks/roles/fwknop-server/tasks/main.yml
+++ b/install/playbooks/roles/fwknop-server/tasks/main.yml
@@ -43,12 +43,22 @@
     insertafter: '^HMAC_KEY_BASE64.*'
     line: 'REQUIRE_SOURCE_ADDRESS Y'
 
+- name: Get the default NIC (IPv4 version
+  when: ansible_default_ipv4 is defined and ansible_default_ipv4.interface is defined
+  set_fact:
+    default_nic: '{{ ansible_default_ipv4.interface }}'
+
+- name: Get the default NIC (IPv6 version
+  when: ansible_default_ipv6 is defined and ansible_default_ipv6.interface is defined
+  set_fact:
+    default_nic: '{{ ansible_default_ipv6.interface }}'
+
 - name: Set the network interface
   notify: Restart fwknop server
   replace:
     path: /etc/fwknop/fwknopd.conf
     regexp: '^#?PCAP_INTF.*'
-    replace: 'PCAP_INTF {{ firewall.fwknop.nic }}'
+    replace: 'PCAP_INTF {{ default_nic }}'
 
 - name: Allow to use a random port
   when: firewall.fwknop.port == 'random'

--- a/install/playbooks/roles/sogo/tasks/main.yml
+++ b/install/playbooks/roles/sogo/tasks/main.yml
@@ -6,6 +6,7 @@
     name: '{{ pkg }}'
     state: present
   with_items:
+    - postgresql
     - sogo-common
     - sogo
     - memcached
@@ -73,13 +74,21 @@
 - name: Initialise the database
   when: sogodb.changed
   tags: postgres
+  register: db_init
   become: true
   become_user: postgres
   shell: >-
     cat /tmp/sogo-db-init.sql
-    | psql -d sogo -o /var/log/sogo/db-install.log
+    | psql -a -d sogo -o /tmp/sogo-db-install.log
   args:
-    creates: /var/log/sogo/db-install.log
+    creates: /tmp/sogo-db-install.log
+
+- name: Keep the DB logs
+  when: db_init.changed
+  copy:
+    src: /tmp/sogo-db-install.log
+    dest: /var/log/sogo/db-install.log
+    remote_src: true
 
 - name: Initialise grants
   tags: postgres

--- a/install/playbooks/roles/sogo/templates/nginx.conf
+++ b/install/playbooks/roles/sogo/templates/nginx.conf
@@ -1,6 +1,9 @@
 server
 {
+    # Listen on both IPv4 and IPv6
     listen 80;
+    listen [::]:80;
+
     server_name sogo.{{ network.domain }};
 
     # Certificate renewal
@@ -20,97 +23,100 @@ server
 
 server
 {
-   listen 443;
-   server_name sogo.{{ network.domain }};
-   root /usr/lib/GNUstep/SOGo/WebServerResources/;
-   ssl on;
-   ssl_certificate /etc/letsencrypt/live/sogo.{{ network.domain }}/fullchain.pem;
-   ssl_certificate_key /etc/letsencrypt/live/sogo.{{ network.domain }}/privkey.pem;
+    # Listen on both IPv4 and IPv6
+    listen 443;
+    listen [::]:443;
 
-   ## requirement to create new calendars in Thunderbird ##
-   proxy_http_version 1.1;
+    server_name sogo.{{ network.domain }};
+    root /usr/lib/GNUstep/SOGo/WebServerResources/;
+    ssl on;
+    ssl_certificate /etc/letsencrypt/live/sogo.{{ network.domain }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/sogo.{{ network.domain }}/privkey.pem;
 
-   # Maximum upload size for attachments
-   client_max_body_size {{ mail.max_attachment_size }}M;
-   client_body_buffer_size 128k;
+    ## requirement to create new calendars in Thunderbird ##
+    proxy_http_version 1.1;
 
-   # Redirect to the main page
-   location = / {
-      rewrite ^ 'https://$server_name/SOGo';
-      allow all;
-   }
+    # Maximum upload size for attachments
+    client_max_body_size {{ mail.max_attachment_size }}M;
+    client_body_buffer_size 128k;
 
-   # For iOS 7
-   location = /principals/ {
-      rewrite ^ 'https://$server_name/SOGo/dav';
-      allow all;
-   }
+    # Redirect to the main page
+    location = / {
+        rewrite ^ 'https://$server_name/SOGo';
+        allow all;
+    }
 
-   location ^~ /SOGo {
-      proxy_pass 'http://127.0.0.1:20000';
-      proxy_redirect 'http://127.0.0.1:20000' default;
+    # For iOS 7
+    location = /principals/ {
+        rewrite ^ 'https://$server_name/SOGo/dav';
+        allow all;
+    }
 
-      # Maximum upload size for attachments
-      client_max_body_size {{ mail.max_attachment_size }}M;
+    location ^~ /SOGo {
+        proxy_pass 'http://127.0.0.1:20000';
+        proxy_redirect 'http://127.0.0.1:20000' default;
 
-      # forward user's IP address
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $host;
-      proxy_set_header x-webobjects-server-protocol HTTP/1.0;
-      proxy_set_header x-webobjects-remote-host 127.0.0.1;
-      proxy_set_header x-webobjects-server-name $server_name;
-      proxy_set_header x-webobjects-server-url $scheme://$host;
-      proxy_set_header x-webobjects-server-port $server_port;
-      proxy_connect_timeout 90;
-      proxy_send_timeout 90;
-      proxy_read_timeout 90;
-      proxy_buffer_size 4k;
-      proxy_buffers 4 32k;
-      proxy_busy_buffers_size 64k;
-      proxy_temp_file_write_size 64k;
-      break;
-   }
+        # Maximum upload size for attachments
+        client_max_body_size {{ mail.max_attachment_size }}M;
 
-   location /SOGo.woa/WebServerResources/ {
-      alias /usr/lib/GNUstep/SOGo/WebServerResources/;
-      allow all;
-      expires 7d;
-   }
+        # forward user's IP address
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_set_header x-webobjects-server-protocol HTTP/1.0;
+        proxy_set_header x-webobjects-remote-host 127.0.0.1;
+        proxy_set_header x-webobjects-server-name $server_name;
+        proxy_set_header x-webobjects-server-url $scheme://$host;
+        proxy_set_header x-webobjects-server-port $server_port;
+        proxy_connect_timeout 90;
+        proxy_send_timeout 90;
+        proxy_read_timeout 90;
+        proxy_buffer_size 4k;
+        proxy_buffers 4 32k;
+        proxy_busy_buffers_size 64k;
+        proxy_temp_file_write_size 64k;
+        break;
+    }
 
-   location /SOGo/WebServerResources/ {
-      alias /usr/lib/GNUstep/SOGo/WebServerResources/;
-      allow all;
-      expires 7d;
-   }
+    location /SOGo.woa/WebServerResources/ {
+        alias /usr/lib/GNUstep/SOGo/WebServerResources/;
+        allow all;
+        expires 7d;
+    }
 
-   location (^/SOGo/so/ControlPanel/Products/([^/]*)/Resources/(.*)$) {
-      alias /usr/lib/GNUstep/SOGo/$1.SOGo/Resources/$2;
-      expires 7d;
-   }
+    location /SOGo/WebServerResources/ {
+        alias /usr/lib/GNUstep/SOGo/WebServerResources/;
+        allow all;
+        expires 7d;
+    }
 
-   location (^/SOGo/so/ControlPanel/Products/[^/]*UI/Resources/.*\.(jpg|png|gif|css|js)$) {
-      alias /usr/lib/GNUstep/SOGo/$1.SOGo/Resources/$2;
-      expires 7d;
-   }
+    location (^/SOGo/so/ControlPanel/Products/([^/]*)/Resources/(.*)$) {
+        alias /usr/lib/GNUstep/SOGo/$1.SOGo/Resources/$2;
+        expires 7d;
+    }
 
-   location ^~ /Microsoft-Server-ActiveSync {
-      access_log /var/log/nginx/sogo-activesync.log;
-      error_log  /var/log/nginx/sogo-activesync-error.log;
-      resolver 127.0.0.1;
+    location (^/SOGo/so/ControlPanel/Products/[^/]*UI/Resources/.*\.(jpg|png|gif|css|js)$) {
+        alias /usr/lib/GNUstep/SOGo/$1.SOGo/Resources/$2;
+        expires 7d;
+    }
 
-      proxy_connect_timeout 75;
-      proxy_send_timeout 3600;
-      proxy_read_timeout 3600;
-      proxy_buffers 64 256k;
+    location ^~ /Microsoft-Server-ActiveSync {
+        access_log /var/log/nginx/sogo-activesync.log;
+        error_log  /var/log/nginx/sogo-activesync-error.log;
+        resolver 127.0.0.1;
 
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 75;
+        proxy_send_timeout 3600;
+        proxy_read_timeout 3600;
+        proxy_buffers 64 256k;
 
-      proxy_pass http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync;
-      proxy_redirect http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync /;
-   }
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_pass http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync;
+        proxy_redirect http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync /;
+    }
 
     # Discovery
     location /.well-known/carddav {

--- a/install/playbooks/roles/system-cleanup/tasks/main.yml
+++ b/install/playbooks/roles/system-cleanup/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+# Remove packages that are not needed for a live system:
+# bash-completion:
+# See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=825153
+# this seems to remove most errors like :
+# <passwd="*"> request denied by validnames option.
+
+- name: Remove useless packages
+  tags: apt
+  apt:
+    name: '{{ pkg }}'
+    state: absent
+  with_items:
+    - bash-completion
+  loop_control:
+    loop_var: pkg
+
+
+# At this point, it might be necessary to reboot
+# To reload all bash instances

--- a/install/playbooks/roles/system-prepare/tasks/main.yml
+++ b/install/playbooks/roles/system-prepare/tasks/main.yml
@@ -124,6 +124,17 @@
   loop_control:
     loop_var: conf
 
+- name: Update /etc/locales
+  tags: locale
+  replace:
+    path: /etc/locale.gen
+    regexp: '^# {{ locale | regex_replace("\.", "\\.") }}'
+    replace: '{{ locale }}'
+
+- name: Configure locales
+  tags: locale
+  shell: dpkg-reconfigure -phigh locales
+
 # Install the firewall, but do not configure any rule.
 # The other tasks will setup the rules themselves
 # We are also installing fail2ban, so the other services might use it, like postfix, dovecot and roundcube
@@ -184,9 +195,11 @@
 - name: Reboot to activate AppArmor if not already active
   when: security.app_armor and aa_enabled.rc == 1
   tags: security, apparmor
-  shell: systemctl reboot --message "Restarting the system to activate AppArmor"
+  shell: >-
+    systemctl reboot --message "Restarting the system to activate AppArmor"
   async: 1
   poll: 0
+  failed_when: false
 
 - name: Wait for the server to come back online
   when: security.app_armor and aa_enabled.rc == 1

--- a/install/playbooks/roles/website-simple/tasks/main.yml
+++ b/install/playbooks/roles/website-simple/tasks/main.yml
@@ -21,7 +21,6 @@
   stat:
     path: /var/www/default/index.html
 
-
 - name: Get remote environment locale
   when: not index_page.stat.exists
   tags: website
@@ -64,7 +63,7 @@
     loop_var: path
 
 - name: Create the website site configuration file
-  tags: website
+  tags: nginx
   notify: Restart nginx
   template:
     src: website-simple.tpl
@@ -74,7 +73,7 @@
     mode: 0644
 
 - name: Enable nginx site
-  tags: website
+  tags: nginx
   notify: Restart nginx
   file:
     src: /etc/nginx/sites-available/website-simple.conf

--- a/install/playbooks/roles/website-simple/templates/website-simple.tpl
+++ b/install/playbooks/roles/website-simple/templates/website-simple.tpl
@@ -2,12 +2,15 @@
 # Default server configuration
 #
 # for http://www.{{ network.domain }} and http://{{ network.domain }}
-# redirect everything to https
+# redirect everything to https except letsencrypt certificate renewal
 {% if system.ssl == 'letsencrypt' %}
 server {
 
-    # Web site FQDN
+    # Listen on both IPv4 and IPv6
     listen 80;
+    listen [::]:80;
+
+    # Web site FQDN
     server_name www.{{ network.domain }} {{ network.domain }};
 
     # Certificate renewal
@@ -32,6 +35,10 @@ server {
 # for https://www.{{ network.domain }}
 server {
 
+    # Listen on both IPv4 and IPv6
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
     # Web site FQDN
     server_name www.{{ network.domain }};
 
@@ -42,29 +49,12 @@ server {
     server_tokens off;
 
     {% if system.ssl == 'letsencrypt' %}
-
     # SSL configuration
-    listen 443 ssl http2;
     ssl_protocols TLSv1.1 TLSv1.2;
     ssl_certificate /etc/letsencrypt/live/www.{{ network.domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/www.{{ network.domain }}/privkey.pem;
     ssl_trusted_certificate /etc/letsencrypt/live/www.{{ network.domain }}/fullchain.pem;
     {% endif %}
-
-    {% if index_page.stat.exists %}
-
-    # Servce the page that exists
-    index index.html;
-
-    # Do not use a favicon
-    location ~ ^/favicon.ico$ {
-        root /var/www/default/;
-        log_not_found off;
-        access_log off;
-        expires max;
-    }
-
-    {% else %}
 
     # Will dynamically fall back to the demo
     # page if there is no index
@@ -78,7 +68,54 @@ server {
         expires max;
     }
 
+    # Nothing here
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    # log files per virtual host
+    access_log /var/log/nginx/website-access.log;
+    error_log /var/log/nginx/website-error.log;
+}
+
+# Default server configuration for
+# https://{{ network.domain }}
+server {
+
+    # Listen on both IPv4 and IPv6
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    # Web site FQDN
+    server_name {{ network.domain }};
+
+    # The default web site
+    root /var/www/default/;
+
+    # Remove useless tokens for better security feelings ;-)
+    server_tokens off;
+
+    {% if system.ssl == 'letsencrypt' %}
+    # SSL configuration
+    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_certificate /etc/letsencrypt/live/{{ network.domain }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ network.domain }}/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/{{ network.domain }}/fullchain.pem;
     {% endif %}
+
+    # Will dynamically fall back to the demo
+    # page if there is no index
+    index index.html index-demo.html;
+
+    # Do not use a favicon
+    location ~ ^/favicon.ico$ {
+        root /var/www/default/;
+        log_not_found off;
+        access_log off;
+        expires max;
+    }
 
     # Nothing here
     location = /robots.txt {

--- a/install/playbooks/system-cleanup.yml
+++ b/install/playbooks/system-cleanup.yml
@@ -1,0 +1,9 @@
+---
+
+# Cleanup the system before going live
+- hosts: homebox
+  vars_files:
+    - '{{ playbook_dir }}/../../config/system.yml'
+    - '{{ playbook_dir }}/../../config/defaults.yml'
+  roles:
+    - system-cleanup


### PR DESCRIPTION
- SOGo: IMAP quota work around (https://sogo.nu/bugs/view.php?id=1494)
- Virtual folders configuration improvements
- Automatically subscribe virtual folders "All" and "Flagged"
- Simplified fwknop installation
- Use the default DNS server to check DNS server propagation
- Default web site simplification
- Fixed a reboot error when enabling AppArmor
- Allow the installation of SOGo without Roundcube
- Allow the certificate to be renewed on an IPv6 IP address
- fwknop: Get the default NIC in the tasks, not in the settings
- Added a system cleanup task, to run before going live