### PR TITLE
Dev arodier

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -348,12 +348,14 @@ ejabberd_default:
 
 ###############################################################################
 # Gandi automatic DNS update
+# This is now obsolete, as Homebox come with its own DNS server
+# However, we could keep this for Glue records management
 # Your Gandi Key should be 24 characters long, e.g. zaNGbUVIvi1KbYb6PPMdiQLh
 # update: Automatic update of your DNS server
 # test: test mode: does not activate the DNS zone straight
 # add_wildcard:  Create a wildcard entry to redirect all traffic to your box
 dns_default:
-  update: true
+  update: false
   test: true
   add_wildcard: true
   gandi:

--- a/install/playbooks/roles/autodiscover/templates/autodiscover.xml
+++ b/install/playbooks/roles/autodiscover/templates/autodiscover.xml
@@ -25,7 +25,7 @@
   <Protocol>
     <Type>SMTP</Type>
     <Server>smtp.{{ network.domain }}</Server>
-    <Port>{{ postfix.submission.port }}</Port>
+    <Port>{{ mail.postfix.submission.port }}</Port>
     <DomainRequired>off</DomainRequired>
     <SPA>off</SPA>
     <SSL>on</SSL>

--- a/install/playbooks/roles/ejabberd/templates/50-jabber.bind
+++ b/install/playbooks/roles/ejabberd/templates/50-jabber.bind
@@ -1,8 +1,13 @@
-;; XMPP Server IP address, should be an A record
-xmpp    IN       A      {{ external_ip }}
+;; XMPP Server IP address, should be an A/AAAA record
+xmpp    IN       {{ "%-4s" | format(external_ip_type) }}      {{ external_ip }}
+{% if backup_ip is defined %}
+xmpp    IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
+{% endif %}
 
-;; RFC 6186 entries, should point to an "A" record
+;; RFC 6186 entries, should point to an A/AAAA record
 _xmpp-client._tcp 3600 IN SRV 5 0 5222 xmpp.{{ network.domain }}.
+
 {% if ejabberd.s2s.active %}
+;; Server to server communication
 _xmpp-server._tcp 3600 IN SRV 5 0 5269 xmpp.{{ network.domain }}.
 {% endif %}

--- a/install/playbooks/roles/ejabberd/templates/ejabberd.yml
+++ b/install/playbooks/roles/ejabberd/templates/ejabberd.yml
@@ -148,7 +148,7 @@ ldap_rootdn: "{{ ldap.readonly.dn }}"
 ldap_password: "{{ lookup('password', ldap.roPasswdParams) }}"
 ldap_base: "{{ ldap.organization.base }}"
 ldap_filter: "(objectClass=shadowAccount)"
-ldap_uids: '[{"uid","%u"}]'
+ldap_uids: '[{"mail","%u@{{ network.domain }}"}]'
 
 ###.  ===============
 ###'  TRAFFIC SHAPERS
@@ -183,6 +183,7 @@ acl:
   loopback:
     ip:
       - "127.0.0.0/8"
+      - "::1/128"
 {% if ejabberd.s2s.active %}
 {% if not ejabberd.s2s.public %}
   ## trusted servers for s2s

--- a/install/playbooks/roles/ejabberd/templates/frontend.tpl
+++ b/install/playbooks/roles/ejabberd/templates/frontend.tpl
@@ -6,10 +6,12 @@
 {% if system.ssl == 'letsencrypt' %}
 server {
 
-    # frontend
+    # Listen on IPv4 and IPv6
     listen 80;
-    server_name xmpp.{{ network.domain }};
+    listen [::]:80;
 
+    # frontend
+    server_name xmpp.{{ network.domain }};
 
     # Certificate renewal
     location /.well-known {
@@ -31,6 +33,10 @@ server {
 # for https://xmpp.{{ network.domain }}
 server {
 
+    # Listen on IPv4 and IPv6
+    listen 443 ssl http2;
+    listen [::]:443;
+
     # frontend
     server_name xmpp.{{ network.domain }};
 
@@ -42,7 +48,6 @@ server {
 
     {% if system.ssl == 'letsencrypt' %}
     # SSL configuration
-    listen 443 ssl http2;
     ssl_protocols TLSv1.1 TLSv1.2;
     ssl_certificate /etc/letsencrypt/live/xmpp.{{ network.domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/xmpp.{{ network.domain }}/privkey.pem;

--- a/install/playbooks/roles/gogs/templates/webui-site.tpl
+++ b/install/playbooks/roles/gogs/templates/webui-site.tpl
@@ -5,6 +5,7 @@ server {
 
     # gogs FQDN
     listen 80;
+    listen [::]:80;
     server_name gogs.{{ network.domain }};
 
     # Certificate renewal
@@ -35,6 +36,10 @@ server {
 # Default server configuration
 server {
 
+    # SSL configuration
+    listen 443 ssl http2;
+    listen [::]:443 ssl;
+
     # gogs FQDN
     server_name gogs.{{ network.domain }};
 
@@ -45,8 +50,6 @@ server {
     server_tokens off;
 
     {% if system.ssl == 'letsencrypt' %}
-    # SSL configuration
-    listen 443 ssl http2;
     ssl_protocols TLSv1.1 TLSv1.2;
     ssl_certificate /etc/letsencrypt/live/gogs.{{ network.domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/gogs.{{ network.domain }}/privkey.pem;

--- a/install/playbooks/roles/nginx/tasks/main.yml
+++ b/install/playbooks/roles/nginx/tasks/main.yml
@@ -60,6 +60,7 @@
   template:
     src: 'apparmor.d/usr.sbin.nginx'
     dest: '/etc/apparmor.d/usr.sbin.nginx'
+    force: no
 
 - name: Activate AppArmor profiles
   when: security.app_armor

--- a/install/playbooks/roles/php-fpm/tasks/main.yml
+++ b/install/playbooks/roles/php-fpm/tasks/main.yml
@@ -4,6 +4,12 @@
   register: timezone
   shell: cat /etc/timezone
 
+- name: Install the required packages
+  tags: apt
+  apt:
+    name: php-fpm
+    state: present
+
 - name: Update PHP configuration
   notify: Restart php-fpm
   replace:
@@ -11,10 +17,6 @@
     regexp: '{{ option.regexp }}'
     replace: '{{ option.replace }}'
   with_items:
-    # - regexp: '^max_execution_time\s=\s[0-9]+'
-    #   replace: 'max_execution_time = 300'
-    # - regexp: '^max_input_time\s=\s[0-9]+'
-    #   replace: 'max_imput_time = 300'
     - regexp: '^;?date.timezone\s=.*'
       replace: 'date.timezone = {{ timezone.stdout }}'
   loop_control:

--- a/install/playbooks/roles/zabbix-server/tasks/main.yml
+++ b/install/playbooks/roles/zabbix-server/tasks/main.yml
@@ -33,6 +33,7 @@
     - python-psycopg2
     - postgresql-client
     - lm-sensors
+    - php-ldap
   loop_control:
     loop_var: pkg
 

--- a/install/playbooks/roles/zabbix-server/templates/webfrontend.conf.j2
+++ b/install/playbooks/roles/zabbix-server/templates/webfrontend.conf.j2
@@ -2,6 +2,7 @@
 server {
 
     listen 80;
+    listen [::]:80;
     server_name zabbix.{{ network.domain }};
 
     # Certificate renewal
@@ -21,7 +22,8 @@ server {
 
 server {
 
-    listen 443;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name zabbix.{{ network.domain }};
     access_log  /var/log/nginx/zabbix-access.log;
     error_log   /var/log/nginx/zabbix-error.log;


### PR DESCRIPTION
More IPv6 test and fixes

- Do not overwrite nginx apparmor template if already existing
- Install php-fpm package in the php-fpm role
- Do not update Gandi DNS by default
- Zabbix: IPv6 listening and php-fpm dependency
- Autodiscover: fixed macro error for postfix submission port
- Make sure Gogs frontend is listening on IPv6
- Jabber: IPv6 compliance
- Add loopback IPv6 adress for ejabberd