### PR TITLE
Dev arodier

### DIFF
--- a/common/roles/external-ip-type/meta/main.yml
+++ b/common/roles/external-ip-type/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - { role: load-defaults, when: defaults_loaded is not defined }

--- a/common/roles/external-ip-type/tasks/main.yml
+++ b/common/roles/external-ip-type/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+
+################################################################################
+# Get the external IP address, from configuration file,
+# or automatically through a script
+
+- name: Run the script to get the external IP address automatically
+  tags: facts
+  when: network.external_ip == "auto"
+  register: external_ip_facts
+  shell: /usr/local/bin/external-ip -u /etc/external-ip.conf
+
+- name: Get the external IP address automatically
+  tags: facts
+  when: network.external_ip == "auto"
+  set_fact:
+    external_ip: '{{ external_ip_facts.stdout }}'
+
+- name: Get the external IP address automatically
+  tags: facts
+  when: network.external_ip != "auto"
+  set_fact:
+    external_ip: '{{ network.external_ip }}'
+
+- name: Set external IP address type (A or AAAA)
+  tags: facts
+  register: main_ip_type
+  shell:
+    echo {{ external_ip }}
+    | grep -E '^[0-9\.]+$' 2>&1 >/dev/null
+    && echo A || echo AAAA
+
+- name: Set external IP address type (A or AAAA)
+  tags: facts
+  set_fact:
+    external_ip_type: '{{ (main_ip_type.stdout) }}'
+
+- name: Get the backup IP address
+  when: network.backup_ip != None
+  tags: facts
+  set_fact:
+    backup_ip: '{{ network.backup_ip }}'
+
+- name: Set backup IP address type (A or AAAA)
+  when: network.backup_ip != None
+  tags: facts
+  register: backup_ip_type
+  shell:
+    echo {{ backup_ip }}
+    | grep -E '^[0-9\.]+$' 2>&1 >/dev/null
+    && echo A || echo AAAA
+
+- name: Set backup IP address type (A or AAAA)
+  tags: facts
+  when: network.backup_ip != None
+  set_fact:
+    backup_ip_type: '{{ (backup_ip_type.stdout) }}'

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -214,6 +214,7 @@ firewall_default:
 security_default:
   auto_update: true
   app_armor: true
+  ssh_disable_root_access_with_password: true
 
 ###############################################################################
 # Dictionaries to install in the system

--- a/docs/codeofconduct.md
+++ b/docs/codeofconduct.md
@@ -17,11 +17,9 @@ Any new service should be compatible with
 and to protect from any zero-day vulnerability.
 
 It is also standard compliant, as the system generates and _publish_
-automatically your DKIM, SPF and DMARC records. It is actually using
-the excellent [Gandi](https://gandi.net) DNS provider, but can be
-extended to support more.
+automatically your DKIM, SPF and DMARC records.
 
-Any system should support LDAP for authentication, for single sign on.
+Any system should support LDAP for authentication, for central authentication.
 
 I am privileging stability and security over features, this is why you
 will not have the latest version of RoundCube and other components.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ This project is for you if:
   [KISS principle](https://en.wikipedia.org/wiki/KISS_principle).
   and safety.
 - Attention to details, keep focused on the nitty-gritty features of
-  self hosting.
+  self hosting, like full IPv6 support.
 
 ## Main components
 

--- a/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
@@ -4,9 +4,13 @@
 - name: Check DNS propagation
   shell: >-
     host main.{{ network.domain }}
+  retries: 10
+  delay: 60
 
 # This is checking that the DNS server has been fully propagated
 - name: Check DNS propagation for backup IP address
   when: network.backup_ip is defined
   shell: >-
     host backup.{{ network.domain }}
+  retries: 10
+  delay: 60

--- a/install/playbooks/roles/external-ip/tasks/main.yml
+++ b/install/playbooks/roles/external-ip/tasks/main.yml
@@ -5,12 +5,14 @@
 # or automatically through a script
 
 - name: Copy the configuration file
+  when: network.external_ip == "auto"
   tags: scripts
   copy:
     src: external-ip.conf
     dest: /etc/external-ip.conf
 
 - name: Copy the external IP address detection script
+  when: network.external_ip == "auto"
   tags: scripts
   copy:
     src: external-ip
@@ -36,6 +38,7 @@
     external_ip: '{{ network.external_ip }}'
 
 - name: Set external IP address type (A or AAAA)
+  tags: facts
   register: main_ip_type
   shell:
     echo {{ external_ip }}
@@ -43,6 +46,7 @@
     && echo A || echo AAAA
 
 - name: Set external IP address type (A or AAAA)
+  tags: facts
   set_fact:
     external_ip_type: '{{ (main_ip_type.stdout) }}'
 
@@ -54,6 +58,7 @@
 
 - name: Set external IP address type (A or AAAA)
   when: network.backup_ip != None
+  tags: facts
   register: backup_ip_type
   shell:
     echo {{ backup_ip }}
@@ -61,6 +66,7 @@
     && echo A || echo AAAA
 
 - name: Set external IP address type (A or AAAA)
+  tags: facts
   when: network.backup_ip != None
   set_fact:
     backup_ip_type: '{{ (backup_ip_type.stdout) }}'

--- a/install/playbooks/roles/ldap/tasks/main.yml
+++ b/install/playbooks/roles/ldap/tasks/main.yml
@@ -414,6 +414,17 @@
     dn: 'cn=manager account,{{ ldap.users.dn }}'
     state: absent
 
+- name: Create the default postmaster aliases
+  tags: postmaster
+  set_fact:
+    postmaster_aliases: '{{ ldap.postmaster.mailAliases }}'
+
+- name: Extend the postmaster aliases when sogo is installed
+  when: sogo.install
+  tags: postmaster
+  set_fact:
+    postmaster_aliases: '{{ postmaster_aliases | union(["sogo@" + network.domain]) }}'
+
 - name: Create the postmaster account
   tags: postmaster
   ldap_entry:
@@ -432,7 +443,7 @@
       uidNumber: '{{ users_defaults.uid_start + 999 }}'
       gidNumber: '{{ users_defaults.gid_start }}'
       mail: 'postmaster@{{ network.domain }}'
-      intlMailAddr: '{{ ldap.postmaster.mailAliases }}'
+      intlMailAddr: '{{ postmaster_aliases }}'
       shadowMin: 0
       shadowMax: 999999
       shadowWarning: 7

--- a/install/playbooks/roles/postfix/templates/30-postfix.bind
+++ b/install/playbooks/roles/postfix/templates/30-postfix.bind
@@ -12,8 +12,11 @@ smtp2   IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 
 ;; RFC 6186 entries, should point to a proper A/AAAA record
 _submission._tcp 3600 IN SRV 0 0 {{ mail.postfix.submission.port }} smtp.{{ network.domain }}.
+{% if backup_ip is defined and backup_ip != "" %}
+_submission._tcp 3600 IN SRV 0 0 {{ mail.postfix.submission.port }} smtp2.{{ network.domain }}.
+{% endif %}
 
-;; SPF record
+;; SPF record: include all MX records
 @       IN       TXT    "v=spf1 mx -all"
 
 {% if bind.mx_backup.count > 0 %}

--- a/install/playbooks/roles/remote-access/handlers/main.yml
+++ b/install/playbooks/roles/remote-access/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Restart SSH
+  service:
+    name: ssh
+    state: restarted

--- a/install/playbooks/roles/remote-access/tasks/main.yml
+++ b/install/playbooks/roles/remote-access/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Remove root password access from SSH
+  when: security.ssh_disable_root_access_with_password
+  tags: security
+  notify: Restart SSH
+  replace:
+    path: /etc/ssh/sshd_config
+    regexp: '^PermitRootLogin yes'
+    replace: 'PermitRootLogin without-password'
+
 - name: Configure the firewall for SSH access
   tags: security
   ufw:

--- a/install/playbooks/roles/transmission/templates/webui-site.tpl
+++ b/install/playbooks/roles/transmission/templates/webui-site.tpl
@@ -9,8 +9,11 @@ upstream transmission  {
 {% if system.ssl == 'letsencrypt' %}
 server {
 
-    # transmission FQDN
+    # Listen on IPv4 and IPv6
     listen 80;
+    listen [::]:80;
+
+    # transmission FQDN
     server_name transmission.{{ network.domain }};
 
     # Certificate renewal
@@ -32,6 +35,10 @@ server {
 # Default server configuration
 server {
 
+    # Listen on IPv4 and IPv6
+    listen 443 ssl http2;
+    listen [::]:443 ssl;
+
     # transmission FQDN
     server_name transmission.{{ network.domain }};
 
@@ -43,7 +50,6 @@ server {
 
     {% if system.ssl == 'letsencrypt' %}
     # SSL configuration
-    listen 443 ssl http2;
     ssl_protocols TLSv1.1 TLSv1.2;
     ssl_certificate /etc/letsencrypt/live/transmission.{{ network.domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/transmission.{{ network.domain }}/privkey.pem;

--- a/install/playbooks/update-users.yml
+++ b/install/playbooks/update-users.yml
@@ -1,0 +1,43 @@
+---
+## Playbook to update users list
+
+# Load default settings once, this is needed to defined
+# some conditional flags used below
+- import_playbook: load-defaults.yml
+
+# Start to create users and home directories
+- import_playbook: ldap.yml
+- import_playbook: homes.yml
+
+# Configure SSH for remote access using borgbackup,
+# But only for users with an ssh key provided.
+# See system-example.yml configuration file
+- import_playbook: backup-server.yml
+
+# Email server: MTA
+- import_playbook: postfix.yml
+
+# Mail delivery agent (dovecot)
+- import_playbook: dovecot.yml
+
+# Install the selected webmail
+- import_playbook: roundcube.yml
+  when: webmail.install and webmail.type == 'roundcube'
+
+# Install SOGo if chosen
+- import_playbook: sogo.yml
+  when: sogo.install
+
+# Install ejabberd, with LDAP authentication
+- import_playbook: ejabberd.yml
+  when: ejabberd.install
+
+# Add the old emails import scripts for each users
+# Except when in development mode.
+# It can alter the tests and is CPU intensive if you have
+# defined a lot of accounts.
+- import_playbook: import-accounts.yml
+  when: mail.import.active and not system.devel
+
+# Clean up the system before going live
+- import_playbook: system-cleanup.yml

--- a/tests/playbooks/dns-records-email.yml
+++ b/tests/playbooks/dns-records-email.yml
@@ -1,5 +1,9 @@
 ---
 
+- hosts: homebox
+  roles:
+    - external-ip-type
+
 # Test the DNS server for mail records
 - hosts: homebox
   vars_files:
@@ -7,7 +11,8 @@
     - '{{ playbook_dir }}/../../config/system.yml'
   vars:
     records:
-      type: A
+      type: '{{ external_ip_type }}'
+      count: '[12]'
       list:
         - main
   roles:
@@ -21,7 +26,8 @@
     - '{{ playbook_dir }}/../../config/system.yml'
   vars:
     records:
-      type: CNAME
+      type: '{{ external_ip_type }}'
+      count: '[12]'
       list:
         - imap
         - smtp
@@ -38,6 +44,7 @@
   vars:
     records:
       type: SRV
+      count: '[12]'
       list:
         - _imap._tcp
         - _imaps._tcp

--- a/tests/playbooks/dns-records-sshfp.yml
+++ b/tests/playbooks/dns-records-sshfp.yml
@@ -8,7 +8,7 @@
   vars:
     records:
       type: SSHFP
-      count: 5
+      count: 6
       list:
         - ''
   roles:

--- a/tests/playbooks/main.yml
+++ b/tests/playbooks/main.yml
@@ -23,17 +23,18 @@
 # Test mail related certificates
 - import_playbook: mail-certificates.yml
 
-# Test mail related certificates
+# Test MTA (postfix) functions
 - import_playbook: postfix.yml
 
-# Test mail related certificates
+# Test MDA (dovecot) functions
 - import_playbook: dovecot.yml
+- import_playbook: dovecot-fts.yml
 
-# Test autoconfiguration
+# Test autoconfiguration server
 - import_playbook: autoconfig.yml
   when: mail.autoconfig
 
-# Test autodiscover
+# Test autodiscover server
 - import_playbook: autodiscover.yml
   when: mail.autodiscover
 

--- a/tests/playbooks/main.yml
+++ b/tests/playbooks/main.yml
@@ -14,6 +14,7 @@
 
 # Test rspamd program
 - import_playbook: rspamd.yml
+  when: mail.antispam.active
 
 # Test opendmarc and opendkim
 - import_playbook: opendmarc.yml

--- a/tests/playbooks/roles/dev-support/tasks/main.yml
+++ b/tests/playbooks/roles/dev-support/tasks/main.yml
@@ -5,6 +5,7 @@
   apt:
     name: '{{ pkg }}'
     state: latest
+    install_recommends: no
   with_items:
     - '{{ devel.packages }}'
   loop_control:

--- a/tests/playbooks/roles/dovecot-fts/tasks/main.yml
+++ b/tests/playbooks/roles/dovecot-fts/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
 # Test the script only, call grep to check for the uuid
-- name: Test parsing script ({{ attachment.description }})
-  when: test_script = true
+- name: 'Test parsing script ({{ attachment.description }})'
+  when: test_script == true
   include_tasks: ./test-script.yml
   with_items:
     - '{{ attachments | selectattr("script_test", "equalto", true) | list }}'
@@ -11,8 +11,8 @@
 
 
 # Full test by sending an email and using dovecot fts to search
-- name: Send email and search using fts ({{ attachment.description }})
-  when: test_dovecot = true
+- name: 'Send email and search using fts ({{ attachment.description }})'
+  when: test_dovecot == true
   include_tasks: ./send-attachment.yml
   with_items:
     - '{{ attachments | selectattr("smtp_test", "equalto", true) | list }}'


### PR DESCRIPTION
- Add sogo specific email address in the LDAP server
- Make sure transmission daemon is listening on IPv6
- Disable ssh root access with password on the first deployment
- Only copy the IP detection scripts when external_ip is set to "auto"
- Retries DNS propagation tests for 10 minutes
- Add backup IP address in the DNS submission records
- Minor documentation updates 