### PR TITLE
DNS: bind9 server IPv6 / IPv4 fixes

### DIFF
--- a/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
@@ -8,3 +8,31 @@
     dest: '/etc/bind/forward.{{ network.domain }}'
     delimiter: '\n'
     regexp: '^.*\.bind$'
+
+- name: Copy DNS entries in bind cache directory (main IP)
+  notify: Restart bind
+  copy:
+    src: '/etc/bind/{{ file }}'
+    dest: '/var/cache/bind/{{ file }}'
+    owner: bind
+    group: bind
+    remote_src: true
+  with_items:
+    - 'forward.{{ network.domain }}'
+    - 'reverse-main.{{ network.domain }}'
+  loop_control:
+    loop_var: file
+
+- name: Copy DNS entries in bind cache directory (backup IP)
+  notify: Restart bind
+  when: backup_ip is defined
+  copy:
+    src: '/etc/bind/{{ file }}'
+    dest: '/var/cache/bind/{{ file }}'
+    owner: bind
+    group: bind
+    remote_src: true
+  with_items:
+    - 'reverse-backup.{{ network.domain }}'
+  loop_control:
+    loop_var: file

--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -35,6 +35,7 @@
     record_name: main
     reverse_ip_address: '{{ reverse_ip }}'
     external_ip_address: '{{ external_ip }}'
+    ip_type: '{{ external_ip_type }}'
     ptr_id: 10
   template:
     src: '{{ file.src }}'
@@ -65,6 +66,7 @@
     record_name: backup
     reverse_ip_address: '{{ reverse_backup_ip }}'
     external_ip_address: '{{ backup_ip }}'
+    ip_type: '{{ backup_ip_type }}'
     ptr_id: 20
   template:
     src: '{{ file.src }}'

--- a/install/playbooks/roles/dns-server-bind/templates/reverse-domain
+++ b/install/playbooks/roles/dns-server-bind/templates/reverse-domain
@@ -11,7 +11,7 @@ $TTL    {{ bind.ttl }}
 
 ;Name Server Information
 @       IN      NS      {{ record_name }}.{{ network.domain }}.
-{{ "%-6s" | format(record_name) }}  IN      {{ "%-4s" | format(external_ip_type) }}    {{ external_ip_address }}
+{{ "%-6s" | format(record_name) }}  IN      {{ "%-4s" | format(ip_type) }}    {{ external_ip_address }}
 
 ;Reverse lookup ({{ record_name }} IP address)
 {{ ptr_id }}      IN      PTR     {{ record_name }}.{{ network.domain }}.

--- a/tests/playbooks/roles/autodiscover/tasks/main.yml
+++ b/tests/playbooks/roles/autodiscover/tasks/main.yml
@@ -4,7 +4,7 @@
   tags: systemctl, autodiscover
   apt:
     name: '{{ pkg }}'
-    state: installed
+    state: present
   with_items:
     - libxml2-utils
   loop_control:


### PR DESCRIPTION
- fixed backup IP address when IPv6 / IPv4 mix
- refresh DNS cache when assembling DNS entries