### PR TITLE
more fixes ready to dev

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -137,11 +137,6 @@ mail_default:
                             # It is useful to put a limit here if you have a lot of messages
                             # and limited hardware resources
   #############################################################################
-  advanced_features: false  # Use some advanced features that will need the latest version
-                            # of dovecot
-                            # from stretch-backports, like those below.
-                            # like sending emails to an international addresses
-                            # (e.g. andré@homebox.space)
   recipient_delimiter: '+'  # The character you want to use to split email address
                             # from mailbox, i.e.:
                             # when receiving a message to john+lists@example.com,

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -52,6 +52,14 @@ folder, in the file __ldap/master.pwd__.
 
 # Import external accounts
 
+There are two ways of importing other emails. The easiest way is to use SOGo
+web interface. In this case, you will see your other account emails in the web
+interface.
+
+The other option is to use the yaml configuration file. The advantage is once this
+set up, external emails will be automatically imported in your main account,
+regardless of the client you are using.
+
 This is detailed in the section [External accounts](external-accounts.md).
 One important thing to know is that this feature requires the creation
 of a Dovecot _master user_, that will be used to import the emails into the folders.
@@ -64,13 +72,34 @@ from the Debian backports repository.
 
 ## International email addresses
 
-The latest versions of dovecot in the Debian Stretch repository has
-better unicode characters support, for email addresses and domains.
+Your main email address should be without ASCII characters only, but the aliases can contains accents,
+for instance:
 
-Unfortunately, this is actually working only internally, between two
-users of the same domain.
+```yaml
 
-The next Debian version should support full SMTPUTF8.
+users:
+- uid: andre
+  cn: André Rodier
+  first_name: André
+  last_name: Rodier
+  mail: andre@homebox.space
+  password: ***********
+  aliases:
+    - andré.rodier@homebox.space
+    - andré@homebox.space
+
+```
+
+### Notes
+
+This is possible if all the software and the platforms involved support it.
+
+Not all major email providers are supporting this, Yahoo mail, for
+instance, does not even let you send an email with an internationalised user names,
+like __andré@homebox.space__.
+
+This feature is not entirely tested yet, but is working so far between two homebox servers
+and SOGo or evolution.
 
 ## Save emails into mail boxes directly
 
@@ -86,6 +115,7 @@ Example with this configuration:
   recipient_delimiter: '~'
 
 ```
+
 For a user with an email address like __john@homebox.space__, any
 email sent to __john~lists@homebox.space__ will be stored in
 the folder "lists".
@@ -113,6 +143,12 @@ dovecot:
     lda_mailbox_autosubscribe: no
 
 ```
+
+### Warning
+
+Using auto create presents a security risks, as it allows anyone to remote create folders
+on your mail server. It is advised to at least change your recipient delimiter from the
+default one.
 
 ## Add Postfix options
 

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -64,18 +64,13 @@ from the Debian backports repository.
 
 ## International email addresses
 
-The latest versions of dovecot in the Debian backports repository has
-better unicode characters support, for email addresses and domains. If
-you are planning to use them, it is better to set the flag
-advanced_features to true.
+The latest versions of dovecot in the Debian Stretch repository has
+better unicode characters support, for email addresses and domains.
 
-__notes__
+Unfortunately, this is actually working only internally, between two
+users of the same domain.
 
-- This has not been intensively tested, and will require an entire
-  documentation section.
-- Not all major email providers are supporting this, Yahoo mail, for
-  instance, does not support internationalised user names, like
-  __andré@homebox.space__.
+The next Debian version should support full SMTPUTF8.
 
 ## Save emails into mail boxes directly
 

--- a/install/playbooks/roles/dovecot/defaults/main.yml
+++ b/install/playbooks/roles/dovecot/defaults/main.yml
@@ -38,3 +38,5 @@ dovecot:
     mail_max_userip_connections: 64
     lda_mailbox_autocreate: no
     lda_mailbox_autosubscribe: no
+  # Authorized characters for the username
+  username_chars: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@

--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -3,21 +3,10 @@
 ################################################################################
 # Install dovecot packages
 # Set the default repository to download dovecot packages
-- name: Use stable repository for dovecot packages
-  when: not mail.advanced_features
-  set_fact:
-    dovecot_repository: stretch
-
-- name: Use backports repository for dovecot advdanced features
-  when: mail.advanced_features
-  set_fact:
-    dovecot_repository: stretch-backports
-
 - name: Install dovecot packages
   tags: dovecot
   apt:
     name: '{{ dovecot.packages }}'
-    default_release: '{{ dovecot_repository }}'
     state: latest
 
 - name: Install dovecot packages for full text search
@@ -26,7 +15,6 @@
   apt:
     name: dovecot-solr
     state: latest
-    default_release: '{{ dovecot_repository }}'
 
 - name: Allow mail damon to access the users directory
   file:
@@ -52,8 +40,7 @@
   loop_control:
     loop_var: path
 
-- name: Generate a strong Diffie Hellman file (for dovecot >= 2.3)
-  when: mail.advanced_features
+- name: Generate a strong Diffie Hellman file
   notify: Restart dovecot
   tags: ssl
   openssl_dhparam:

--- a/install/playbooks/roles/dovecot/templates/conf.d/10-auth.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/10-auth.conf
@@ -38,9 +38,9 @@ disable_plaintext_auth = yes
 # vulnerabilities with SQL/LDAP databases. If you want to allow all characters,
 # set this value to empty.
 {% if mail.impersonate.active or mail.import.active %}
-auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@{{ mail.impersonate.separator }}
+auth_username_chars = {{ dovecot.username_chars }}{{ mail.recipient_delimiter }}{{ mail.impersonate.separator }}
 {% else %}
-auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@
+auth_username_chars = {{ dovecot.username_chars }}{{ mail.recipient_delimiter }}
 {% endif %}
 
 # Username character translations before it's looked up from databases. The

--- a/install/playbooks/roles/dovecot/templates/conf.d/10-auth.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/10-auth.conf
@@ -37,9 +37,7 @@ disable_plaintext_auth = yes
 # an extra check to make sure user can't exploit any potential quote escaping
 # vulnerabilities with SQL/LDAP databases. If you want to allow all characters,
 # set this value to empty.
-{% if mail.advanced_features %}
-auth_username_chars =
-{% elif mail.impersonate.active or mail.import.active %}
+{% if mail.impersonate.active or mail.import.active %}
 auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@{{ mail.impersonate.separator }}
 {% else %}
 auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@

--- a/install/playbooks/roles/dovecot/templates/conf.d/10-ssl.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/10-ssl.conf
@@ -50,9 +50,6 @@ protocol pop3 {
 
 # DH parameters
 ssl_dh_parameters_length = 2048
-{% if mail.advanced_features %}
-ssl_dh=</etc/dovecot/private/dh.pem
-{% endif %}
 
 # SSL protocols to use
 #ssl_protocols = !SSLv3

--- a/install/playbooks/roles/dovecot/templates/conf.d/15-lda.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/15-lda.conf
@@ -29,15 +29,12 @@
 #rejection_reason = Your message to <%t> was automatically rejected:%n%r
 
 # Delimiter character between local-part and detail in email address.
-recipient_delimiter = "{{ mail.recipient_delimiter[0] }}"
+recipient_delimiter = {{ mail.recipient_delimiter[0] }}
 
 # Header where the original recipient address (SMTP's RCPT TO: address) is taken
 # from if not available elsewhere. With dovecot-lda -a parameter overrides this.
 # A commonly used header for this is X-Original-To.
 lda_original_recipient_header = X-Original-To
-
-# The following works only when using dovecot as an local delivery agent (LDA)
-# This does not work yet when using the ltmp server of Dovecot
 
 # Should saving a mail to a nonexistent mailbox automatically create it?
 lda_mailbox_autocreate = {{ dovecot.settings.lda_mailbox_autocreate | ternary("yes", "no") }}

--- a/install/playbooks/roles/dovecot/templates/conf.d/90-plugin.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/90-plugin.conf
@@ -51,6 +51,15 @@ plugin {
 
   sieve_global_extensions = +vnd.dovecot.pipe
 
+  # Quotas status service for postfix.
+  # Returning DUNNO when no user is necessary with Dovecot < 2.3
+  # https://github.com/progmaticltd/homebox/issues/88
+  # Official doc: https://wiki2.dovecot.org/Quota
+  quota_grace = 10%%
+  quota_status_success = DUNNO
+  quota_status_nouser = DUNNO
+  quota_status_overquota = "552 5.2.2 Mailbox is full"
+
   # Add dovecot fts config
 {% if mail.fts.active %}
   fts = solr

--- a/install/playbooks/roles/dovecot/templates/dovecot-ldap.conf.ext
+++ b/install/playbooks/roles/dovecot/templates/dovecot-ldap.conf.ext
@@ -133,7 +133,7 @@ user_attrs = homeDirectory=home,uidNumber=uid,gidNumber=gid,mail=mail,uid=user
 #   %u - username
 #   %n - user part in user@domain, same as %u if there's no domain
 #   %d - domain part in user@domain, empty if user there's no domain
-user_filter = (&(objectClass=posixAccount)(|(uid=%n)(mail=%u)(intlMailAddr=%u)))
+user_filter = (&(objectClass=posixAccount)(|(uid=%n)(mail=%u)))
 
 # Password checking attributes:
 #  user: Virtual user name (user@domain), if you wish to change the
@@ -151,7 +151,7 @@ pass_attrs = uid=user,userPassword=password,mail=mail
 #  homeDirectory=userdb_home,uidNumber=userdb_uid,gidNumber=userdb_gid,mail=userdb_mail
 
 # Filter for password lookups
-pass_filter = (&(objectClass=posixAccount)(|(uid=%n)(intlMailAddr=%u)(mail=%u)(cn=%u)))
+pass_filter = (&(objectClass=posixAccount)(|(uid=%n)(mail=%u)(cn=%u)))
 
 # Attributes and filter to get a list of all users
 #iterate_attrs = uid=user

--- a/install/playbooks/roles/luks-remote/tasks/set-dropbear.yml
+++ b/install/playbooks/roles/luks-remote/tasks/set-dropbear.yml
@@ -3,7 +3,7 @@
 - name: Install the required packages
   tags: apt
   vars:
-    pkg:
+    pkgs:
       - busybox
       - dropbear
       - dropbear-initramfs

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -138,6 +138,7 @@
     - usr.sbin.sendmail
     - usr.sbin.postdrop
     - usr.sbin.postqueue
+    - usr.sbin.postalias
 
 - name: Install some postfix AppArmor profile
   when: security.app_armor

--- a/install/playbooks/roles/postfix/templates/apparmor.d/usr.sbin.postalias
+++ b/install/playbooks/roles/postfix/templates/apparmor.d/usr.sbin.postalias
@@ -1,0 +1,16 @@
+# Last Modified: Sat Mar 16 11:12:16 2019
+#include <tunables/global>
+
+/usr/sbin/postalias {
+  #include <abstractions/base>
+
+  # binaries
+  /lib/x86_64-linux-gnu/ld-*.so mr,
+  /usr/sbin/postalias mr,
+
+  # Configuration files
+  /etc/__db.aliases.db rw,
+  /etc/aliases r,
+  /etc/aliases.db w,
+  /etc/postfix/dynamicmaps.cf.d/ r,
+}

--- a/install/playbooks/roles/postfix/templates/main.cf
+++ b/install/playbooks/roles/postfix/templates/main.cf
@@ -57,6 +57,10 @@ virtual_mailbox_maps = ldap:/etc/postfix/ldap-aliases.cf
 virtual_mailbox_domains = {{ network.domain }}
 virtual_transport = lmtp:unix:private/dovecot-lmtp
 
+# Do not use NIS for now (remove warnings "dict_nis_init: NIS domain name not set - NIS lookups disabled")
+# https://unix.stackexchange.com/questions/244199/postfix-mail-logs-keep-showing-nis-domain-not-set
+alias_maps = hash:/etc/aliases
+
 # Rewrite recipient, remove recipient delimiter and mailbox
 canonical_maps = ldap:/etc/postfix/ldap-aliases.cf
 
@@ -79,7 +83,7 @@ inet_interfaces = all
 inet_protocols = all
 
 # The set of characters that can separate a user name from its extension
-recipient_delimiter = "{{ mail.recipient_delimiter[0] }}"
+recipient_delimiter = {{ mail.recipient_delimiter[0] }}
 
 # DKIM mails signing / rspamd mail filtering
 milter_default_action = accept
@@ -104,7 +108,7 @@ non_smtpd_milters =
 {% endif %}
 
 # The macros that are sent to Milter applications after the SMTP MAIL FROM command.
-milter_mail_macros =  i {mail_addr} {client_addr} {client_name} {auth_authen} {auth_type}
+milter_mail_macros = i {mail_addr} {client_addr} {client_name} {auth_authen} {auth_type}
 
 # Access restrictions for mail relay control that the Postfix SMTP server applies
 # in the context of the RCPT TO command, before smtpd_recipient_restrictions.
@@ -112,8 +116,8 @@ smtpd_relay_restrictions =
     permit_mynetworks
     permit_sasl_authenticated
     defer_unauth_destination
-    check_policy_service inet:localhost:{{ mail.quota.port }}
     check_policy_service unix:private/policy-spf
+    check_policy_service inet:localhost:{{ mail.quota.port }}
 {% for url in dns_blacklists %}
     reject_rbl_client {{ url }}
 {% endfor %}
@@ -136,6 +140,7 @@ sender_bcc_maps = hash:/etc/postfix/senders-bcc.cf
 # Message size, computed from max attachment size and base64 overhead
 message_size_limit = {{ message_size_limit }}
 
+# Help: http://www.postfix.org/SMTPUTF8_README.html
 smtputf8_enable = yes
 smtputf8_autodetect_classes = verify
 

--- a/install/playbooks/roles/roundcube/templates/config.inc.php
+++ b/install/playbooks/roles/roundcube/templates/config.inc.php
@@ -124,11 +124,9 @@ $config['ldap_public']['users'] = [
     ]
 ];
 
-{% if mail.advanced_features %}
 // Disables saving sent messages in Sent folder (like gmail)
 // The SMTP server does that already
 $config['no_save_sent_messages'] = true;
-{% endif %}
 
 // Allow browser-autocompletion on login form.
 $config['login_autocomplete'] = 2;

--- a/install/playbooks/roles/rspamd/tasks/main.yml
+++ b/install/playbooks/roles/rspamd/tasks/main.yml
@@ -22,14 +22,13 @@
 
 - name: Install rspamd packages
   tags: rspamd
+  vars:
+    pkgs:
+      - redis-server
+      - rspamd
   apt:
-    name: "{{ pkg }}"
+    name: "{{ pkgs }}"
     state: present
-  with_items:
-    - redis-server
-    - rspamd
-  loop_control:
-    loop_var: pkg
 
 - name: Set facts for rspamd password generation
   tags: rspamd


### PR DESCRIPTION
Do not use the backports repository for dovecot
Postfix updates: added postalias AppArmor profile
Do not copy messages in the sent folder with Roundcube
Small fix on dropbear role
Updated email documentation.
Quota service fix with mail extensions and unicode email addresses
- Remove email aliases from user and pass LDAP filters.
- Remove quotes from the recipient delimitier list.
  options.
- Fix authentication username characters according to the deploymen

Dovecot fixes
- Add comments in the configuration file
- Move mail quota milter to last position
- Removed NIS warnings

postfix improvements and small fixes
Email configuration documentation updates
Removed Ansible apt loop on rspamd