### PR TITLE
Dev arodier

### DIFF
--- a/install/playbooks/roles/dovecot/templates/sieve/before-global.sieve
+++ b/install/playbooks/roles/dovecot/templates/sieve/before-global.sieve
@@ -32,6 +32,7 @@ if envelope :matches "to" "*@{{ network.domain }}" {
 if string :is "${from}{{ mail.recipient_delimiter[0] }}Sent" "${to}" {
   setflag "\\Seen";
   fileinto "Sent";
+  keep;
   stop;
 }
 

--- a/install/playbooks/roles/dovecot/templates/sieve/sent-checks.sieve
+++ b/install/playbooks/roles/dovecot/templates/sieve/sent-checks.sieve
@@ -1,47 +1,29 @@
 # IMAP clients are using the APPEND verb to store sent emails in the Sent folder.
 # However, homebox already send a blind copy to the same user to be directly
 # stored in the sent folder, using recipient delimiter and +Sent.
-# Emails appended by IMAP clients to the sent folder should be discarded.
+# In this case, this would create a "duplicate" email, with the same Message-ID header.
 require [
-  "imap4flags",
   "variables",
   "environment",
+  "duplicate",
   "imapsieve"
 ];
 
-# Keep the emails sent from the platform (e.g. should match *+Sent)
-# This is normally not necessary, as bcc'ed emails are filtered by
-# the previous "before-global" sieve filter.
-# It is kept here in case we would copy sent emails in the sent folfer
-# manually, for instance after a backup
-if header :matches "Delivered-To" "*{{ mail.recipient_delimiter[0] }}Sent" {
-  keep;
-  stop;
-}
-
 {% if mail.import.active %}
-# Keep emails imported automatically
+# Keep emails imported automatically, trust the user choice or the other server.
 if environment :matches "imap.user" "*" {
   set "user" "${1}";
 }
-if string :matches "${user}" "*{{ mail.import.username }}*" {
+if string :matches "${user}" "{{ mail.import.username }}" {
   keep;
   stop;
 }
 {% endif %}
 
-# Keep messages marked as "not read", this will be useful to force the import
-# of messages from another account. Mark them as read, though.
-if not hasflag "\\Seen" {
-  setflag "\\Seen";
-  keep;
-  stop;
+# Discard duplicate messages based on Message-ID in this folder, perhaps a
+# client already made a copy in the Sent folder.
+# Some email clients keep the same Message-ID when using the feature "edit as new"
+# The one second prevent different messages to be deleted.
+if duplicate :seconds 1 {
+   discard;
 }
-
-# When importing sent messages from another account,
-# the from email address can be another domain
-# It might be possible to send a warning to the user if its email client
-# is configured to save a copy of sent emails in the "Sent" folder.
-# Discard the emails for now.
-# TODO: Check if this is working with automatic emails import
-discard;

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -74,6 +74,7 @@
     - main.cf
     - ldap-aliases.cf
     - senders-bcc.cf
+    - headers-check.cf
   loop_control:
     loop_var: file
 

--- a/install/playbooks/roles/postfix/templates/headers-check.cf
+++ b/install/playbooks/roles/postfix/templates/headers-check.cf
@@ -1,3 +1,3 @@
-# Remove user agent details
-/^User-Agent:/       IGNORE
-/^X-Mailer:/         IGNORE
+# Remove user agent versions
+/^User-Agent: ([a-z-_\s]+).*/           REPLACE User-Agent: $1
+/^X-Mailer: ([a-z-_\s]+).*/             REPLACE X-Mailer: $1

--- a/install/playbooks/roles/postfix/templates/headers-check.cf
+++ b/install/playbooks/roles/postfix/templates/headers-check.cf
@@ -1,0 +1,3 @@
+# Remove user agent details
+/^User-Agent:/       IGNORE
+/^X-Mailer:/         IGNORE

--- a/install/playbooks/roles/postfix/templates/master.cf
+++ b/install/playbooks/roles/postfix/templates/master.cf
@@ -16,6 +16,7 @@ smtp      inet  n       -       y       -       -       smtpd
 #tlsproxy  unix  -       -       y       -       0       tlsproxy
 submission inet n       -       y       -       -       smtpd
   -o syslog_name=postfix/submission
+  -o header_checks=regexp:/etc/postfix/headers-check.cf
 #  -o smtpd_tls_security_level=encrypt
 #  -o smtpd_sasl_auth_enable=yes
 #  -o smtpd_reject_unlisted_recipient=no

--- a/install/playbooks/roles/postfix/templates/master.cf
+++ b/install/playbooks/roles/postfix/templates/master.cf
@@ -14,9 +14,11 @@ smtp      inet  n       -       y       -       -       smtpd
 #smtpd     pass  -       -       y       -       -       smtpd
 #dnsblog   unix  -       -       y       -       0       dnsblog
 #tlsproxy  unix  -       -       y       -       0       tlsproxy
+subcleanup unix  n       -       -       -       0       cleanup
+    -o header_checks=pcre:/etc/postfix/headers-check.cf
 submission inet n       -       y       -       -       smtpd
   -o syslog_name=postfix/submission
-  -o header_checks=regexp:/etc/postfix/headers-check.cf
+  -o cleanup_service_name=subcleanup
 #  -o smtpd_tls_security_level=encrypt
 #  -o smtpd_sasl_auth_enable=yes
 #  -o smtpd_reject_unlisted_recipient=no

--- a/install/playbooks/roles/sogo/tasks/main.yml
+++ b/install/playbooks/roles/sogo/tasks/main.yml
@@ -37,11 +37,13 @@
 # Database configuration ======================================================
 
 - name: Initialise the sogo database password parameters
+  tags: facts
   set_fact:
     sogo_password_params: "{{ playbook_dir }}/../../backup/{{ network.domain }}/postgresql/sogo.pwd {{ policies.system.password }}"
     roPasswdParams: "{{ playbook_dir }}/../../backup/{{ network.domain }}/ldap/readonly.pwd length=16 chars=ascii_letters,digits"
 
 - name: Create the sogo database account password
+  tags: facts
   set_fact:
     sogo_db_password: '{{ lookup("password", sogo_password_params) }}'
 
@@ -102,14 +104,17 @@
 # Other configuration =========================================================
 
 - name: Get server's timezone
+  tags: config
   register: tz_command
   command: cat /etc/timezone
 
 - name: Get the server timezone
+  tags: config
   set_fact:
     server_time_zone: '{{ tz_command.stdout }}'
 
 - name: Copy sogo configuration
+  tags: config
   notify: Restart sogo service
   template:
     src: sogo.conf
@@ -119,6 +124,7 @@
     mode: 0640
 
 - name: Copy sogo cron table
+  tags: config
   template:
     src: sogo.cron
     dest: '/etc/cron.d/sogo'

--- a/install/playbooks/roles/sogo/templates/sogo.conf
+++ b/install/playbooks/roles/sogo/templates/sogo.conf
@@ -19,14 +19,18 @@
 
   // Mail parameters
   SOGoMailingMechanism = smtp;
-  SOGoSMTPServer = smtp.{{ network.domain }};
-  SOGoSentFolderName = Sent;
+  SOGoSMTPAuthenticationType = plain;
+  SOGoSMTPServer = "smtp.{{ network.domain }}:587";
   SOGoTrashFolderName = Trash;
   SOGoDraftsFolderName = Drafts;
   SOGoIMAPServer = "imap://imap.{{ network.domain }}:143/?tls=YES";
   SOGoSieveServer = "sieve://imap.{{ network.domain }}:4190/?tls=YES";
   SOoIMAPAclConformsToIMAPExt = NO;
   SOGoMailAuxiliaryUserAccountsEnabled = {{ sogo.auxiliary_accounts | ternary("YES", "NO") }};
+  // Do not save copy of emails in the sent folder
+  // See https://sogo.nu/bugs/view.php?id=4722
+  // SOGoSentFolderName = Sent;
+  // Thankfully, the interface still recognise the Sent IMAP folder as the Sent folder.
 
   // Sieve
   SOGoVacationEnabled = {{ sogo.vacation | ternary("YES", "NO") }};


### PR DESCRIPTION
Latest small developments and improvements:
  - Remove user agent versions when sending an email, for instance:
    - User-Agent: SOGo 3.6 ⇒ User-Agent: SOGo
    - X-Mailer: Evolution 3.22.6-1+deb9u1 ⇒ X-Mailer: Evolution
  - Disable the automatic copy of emails in the Sent folder when sending emails with SOGo.

Email copies are done by the server, like GMail, for instance.