### PR TITLE
Allow some users to use sudo and SSH access to administer the system

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -248,9 +248,11 @@ firewall_default:
 ###############################################################################
 # Extra security values
 security_default:
-  auto_update: true
-  ssh_disable_root_access_with_password: true
-  lock_root_password: true
+  auto_update: true                             # Install security updates automatically, using unattended-upgrades
+  ssh_disable_root_access_with_password: true   # Force SSH authentication to use public / private key
+  ssh_disable_root_access: false                # At the end of the installation, completely disable remote
+                                                # root access via SSH and for the use of sudo
+  lock_root_password: true                      # Disable console root access by locking root account
   alerts_email:
     - 'admin@{{ network.domain }}'
   # various options when luks is installed

--- a/config/system-example.yml
+++ b/config/system-example.yml
@@ -28,6 +28,14 @@ users:
       password: ebsipmfwuqsopxsg
       get_junk: true
       get_trash: true
+  # Allow SSH access and system administration with sudo for this user
+  ssh_key:
+    type: ecdsa-sha2-nistp384
+    comment: john@homebox
+    data: >-
+      AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBE+E0hiYkPywn43g2J5s5t8mGq
+      muUwObvFN05lCYpEQYv002lMeZEcD9rN80ZBGXJ49J0pfHmuRYScHIt3SjP7Eau3UrGebHvXSBzqPI
+      xcLmuv8NO2siwhqWmZfvrXEWlQ==
   # Allow access to backup
   backup_ssh_key:
     type: ssh-rsa

--- a/config/system-example.yml
+++ b/config/system-example.yml
@@ -28,7 +28,9 @@ users:
       password: ebsipmfwuqsopxsg
       get_junk: true
       get_trash: true
-  # Allow SSH access and system administration with sudo for this user
+  # This user will be part of the sudo group
+  sudo: true
+  # Allow remote access using SSH
   ssh_key:
     type: ecdsa-sha2-nistp384
     comment: john@homebox

--- a/install/playbooks/roles/remote-access/tasks/main.yml
+++ b/install/playbooks/roles/remote-access/tasks/main.yml
@@ -18,3 +18,38 @@
   user:
     name: root
     password_lock: '{{ security.lock_root_password }}'
+
+# These tasks are configuring the system to give access
+# to some administrators, without having to logon as root.
+# You need to define a public SSH key for each user.
+# see example YAML file
+- name: Add SSH keys for the administrators
+  register: administrators
+  authorized_key:
+    user: '{{ user.uid }}'
+    state: present
+    key: >-
+      {{ user.ssh_key.type }}
+      {{ user.ssh_key.data | regex_replace(" ") }}
+      {{ user.ssh_key.comment }}
+  with_items:
+    - '{{ users | selectattr("ssh_key", "defined") | list }}'
+  loop_control:
+    loop_var: user
+
+- name: Install the sudo package
+  when: users | selectattr("ssh_key", "defined") | list != []
+  apt:
+    name: sudo
+    state: latest
+
+- name: Add thes administrators to the sudo group
+  when: users | selectattr("ssh_key", "defined") | list != []
+  user:
+    name: '{{ user.uid }}'
+    groups:
+      - sudo
+  with_items:
+    - '{{ users | selectattr("ssh_key", "defined") | list }}'
+  loop_control:
+    loop_var: user

--- a/install/playbooks/roles/remote-access/tasks/main.yml
+++ b/install/playbooks/roles/remote-access/tasks/main.yml
@@ -24,7 +24,6 @@
 # You need to define a public SSH key for each user.
 # see example YAML file
 - name: Add SSH keys for the administrators
-  register: administrators
   authorized_key:
     user: '{{ user.uid }}'
     state: present
@@ -37,19 +36,22 @@
   loop_control:
     loop_var: user
 
+- name: Get the administrators
+  set_fact:
+    administrators: '{{ users | selectattr("sudo", "defined") | selectattr("sudo", "equalto", true) | list }}'
+
 - name: Install the sudo package
-  when: users | selectattr("ssh_key", "defined") | list != []
+  when: administrators != []
   apt:
     name: sudo
     state: latest
 
-- name: Add thes administrators to the sudo group
-  when: users | selectattr("ssh_key", "defined") | list != []
+- name: Add the administrators to the sudo group
   user:
     name: '{{ user.uid }}'
     groups:
       - sudo
   with_items:
-    - '{{ users | selectattr("ssh_key", "defined") | list }}'
+    - '{{ administrators | list }}'
   loop_control:
     loop_var: user

--- a/install/playbooks/roles/system-cleanup/handlers/main.yml
+++ b/install/playbooks/roles/system-cleanup/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Restart SSH
+  service:
+    name: ssh
+    state: restarted
+

--- a/install/playbooks/roles/system-cleanup/tasks/main.yml
+++ b/install/playbooks/roles/system-cleanup/tasks/main.yml
@@ -12,5 +12,20 @@
     name: '{{ cleanup_packages }}'
     state: absent
 
+- name: Check if some users are configured with remote access
+  set_fact:
+    user_remote: '{{ users | selectattr("ssh_key", "defined") | list != [] }}'
+
+- name: Completely disable root SSH login
+  when: user_remote and security.ssh_disable_root_access
+  tags: security
+  notify: Restart SSH
+  replace:
+    path: /etc/ssh/sshd_config
+    regexp: '^PermitRootLogin without-password'
+    replace: 'PermitRootLogin no'
+    mode: 0600
+
+
 # At this point, it might be necessary to reboot
 # To reload all bash instances


### PR DESCRIPTION
This can be used to disable root login at all, if this is is the favoured remote access method.