### PR TITLE
Changed macro in dovecot configuration

### DIFF
--- a/install/playbooks/roles/dovecot/templates/conf.d/10-master.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/10-master.conf
@@ -72,7 +72,7 @@ service imap {
 {% endif %}
 }
 
-{% if mail.import.active or mail.log_access %}
+{% if mail.import.active or access_check.active %}
 # The service name below doesn't actually matter.
 service imap-postlogin {
 


### PR DESCRIPTION
access logging has now its dedicated structure, access_check