### PR TITLE
Backup and restore improvements

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -460,6 +460,8 @@ bind_default:
   dnssec:
     active: false
     algo: RSASHA256
+  # Aditional records to be generated
+  extra_records: []
 
 ###############################################################################
 # Gogs installation with LDAP authentication

--- a/config/system-example.yml
+++ b/config/system-example.yml
@@ -276,6 +276,11 @@ users:
 #   dnssec:
 #     active: true
 #     algo: RSASHA256
+#   # Aditional extrernal records to be generated
+#   extra_records:
+#     - name: store
+#       ip: 12.56.14.144
+#       type: A
 
 # Optional packages
 # tor:

--- a/docs/backup-home.md
+++ b/docs/backup-home.md
@@ -53,12 +53,15 @@ backup:
     keep_weekly: 4                   # Keep the last four weeks (1 by default)
     keep_monthly: 6                  # Keep the last six months (1 by default)
     compression: zlib,9              # Use the good but slow compression for weekly backups
+    rate_limit: 500                  # Network upload rate limit in kiByte/s
 ```
 
-When needed, the locations are automatically mounted when the backup starts, and dismounted once
-the backup finished.
+The locations are automatically mounted on demand when the backup starts, and dismounted once the backup finished. You
+can have different backup frequencies, for instance daily, weekly or monthly.
 
-You can have different backup frequencies, for instance daily, weekly or monthly.
+!!! Tip
+    Set up a rate limit when creating a remote backup. This will prevent the backup process to consume all your
+    bandwidth and affect the email delivery.
 
 # Backup locations details
 
@@ -217,6 +220,7 @@ backup:
     secret_access_key: gBiRu5hPSyswK17TNpp2IIf5sWDNJx6Vb9Gx3rjF
     bucket_name: homebox-backup.example.com
     region: eu-west-2
+    rate_limit: 500
 ```
 
 And here an appropriate example of bucket policy:
@@ -247,8 +251,8 @@ decrypt your files without the encryption key.
 !!! Note
     - This location storage is actually under scrutiny, and might be removed if proven unstable.
     - Under the hood, [S3FS](https://github.com/s3fs-fuse/s3fs-fuse) is used, with the cache option activated, and located
-      in /home/.backup-cache/. Because this folder content is about the size if the whole backup, the /home partition should
-      have enough available disk space.
+      in /home/.backup-cache/. Because this folder content is about the size if the whole backup, the /home partition
+      should have enough available disk space.
 
 # Backup contents
 
@@ -269,7 +273,7 @@ By default, backup jobs are run overnight, and an email is sent to the postmaste
 
 ## Example of backup success email
 
-``` html
+```text
 
 Backup report for nas1: Success
 Creation status:

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -34,6 +34,11 @@ cd install
 ansible-playbook -v -i ../config/hosts.yml -t restore playbooks/borgbackup.yml
 ```
 
+!!! Note
+    This step restores all the emails from the last backup. It does not restore your emails from a "previous"
+    state. Therefore, it does not delete any emails that have been created _after_ the backup. The same is happening for
+    calendar events and contacts.
+
 # Complete restoration
 
 This is the disaster recovery option.

--- a/install/playbooks/borgbackup.yml
+++ b/install/playbooks/borgbackup.yml
@@ -12,19 +12,27 @@
 # As the key is going to be loaded non interactively and restricted to run borg
 # it does not make sense to add a passphrase.
 
+# Start by forcing load defaults, if the acript is used manually by itself
+- hosts: homebox
+  vars_files:
+    - '{{ playbook_dir }}/../../config/system.yml'
+    - '{{ playbook_dir }}/../../config/defaults.yml'
+  roles:
+    - load-defaults
+
 - hosts: homebox
   vars_files:
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   vars:
     key:
-      path: '{{ backup.key.path }}'
-      user: '{{ backup.key.user }}'
-      comment: '{{ backup.key.comment }}'
+      path: '{{ backup.key.path | default("/root/.ssh/") }}'
+      user: '{{ backup.key.user | default("root" )}}'
+      comment: '{{ backup.key.comment | default("Backup SSH key") }}'
       passphrase: ~
-      name: '{{ backup.key.name }}'
-      type: '{{ backup.key.type }}'
-      size: '{{ backup.key.size }}'
+      name: '{{ backup.key.name | default("backup.rsa") }}'
+      type: '{{ backup.key.type | default("rsa") }}'
+      size: '{{ backup.key.size | default("2048") }}'
   roles:
     - ssh-keygen
     - borg-backup

--- a/install/playbooks/roles/borg-backup/tasks/install-protocol-cifs.yml
+++ b/install/playbooks/roles/borg-backup/tasks/install-protocol-cifs.yml
@@ -32,15 +32,34 @@
       value: '{{ location.keep_monthly | default(1) }}'
     - name: compression
       value: '{{ location.compression | default("lz4") }}'
+    - name: rate_limit
+      value: '{{ location.rate_limit | default(0) }}'
   loop_control:
     loop_var: option
-
 
 # For Samba drives, uses cifs-utils
 - name: Install the required file systems
   apt:
     name: 'cifs-utils'
     state: latest
+
+- name: Configure the firewall to allow CIFS out connections
+  tags: ufw
+  ufw:
+    direction: out
+    proto: '{{ rule.proto }}'
+    port: '{{ rule.ports }}'
+    comment: '{{ rule.comment }}'
+    rule: allow
+  with_items:
+    - proto: udp
+      ports: 137,138
+      comment: 'Allow samba output connections for backup {{ location.name }}'
+    - proto: tcp
+      ports: 139,445
+      comment: 'Allow samba output connections for backup {{ location.name }}'
+  loop_control:
+    loop_var: rule
 
 - name: Create the credentials file
   template:

--- a/install/playbooks/roles/borg-backup/tasks/install-protocol-s3fs.yml
+++ b/install/playbooks/roles/borg-backup/tasks/install-protocol-s3fs.yml
@@ -59,6 +59,8 @@
       value: '{{ location.keep_monthly | default(1) }}'
     - name: compression
       value: '{{ location.compression | default("lz4") }}'
+    - name: rate_limit
+      value: '{{ location.rate_limit | default(0) }}'
   loop_control:
     loop_var: option
 

--- a/install/playbooks/roles/borg-backup/tasks/main.yml
+++ b/install/playbooks/roles/borg-backup/tasks/main.yml
@@ -18,6 +18,17 @@
     path: /mnt/backup
     state: directory
 
+- name: Create the directories to import and export the keys
+  file:
+    path: '{{ path }}'
+    state: directory
+    mode: 0700
+  with_items:
+      - /tmp/backup-keys-import
+      - /tmp/backup-keys-export
+  loop_control:
+    loop_var: path
+
 - name: Create the backup config into /etc/homebox
   tags: config
   ini_file:
@@ -59,7 +70,7 @@
   tags: config
   template:
     src: cron-check-script.sh
-    dest: '/etc/cron.{{ location.check_frequency | default("monthly") }}/backup-check-{{ location.name }}'
+    dest: '/etc/cron.{{ location.check_frequency | default("weekly") }}/backup-check-{{ location.name }}'
     mode: '0700'
   with_items:
     - '{{ backup.locations | default([]) }}'
@@ -88,17 +99,6 @@
     dest: '/usr/local/sbin/backup'
     mode: '0700'
 
-- name: Initialise the repository, to test access and retrieve the key
-  when: backup.locations is defined and backup.locations != []
-  tags: backup
-  shell: >-
-    /usr/local/sbin/backup --action init --config {{ location.name }}
-  with_items:
-    - '{{ backup.locations }}'
-  loop_control:
-    loop_var: location
-
-
 - name: Create sync directories to import/export keys
   tags: sync
   file:
@@ -126,6 +126,7 @@
   synchronize:
     src: '{{ backup_directory }}/backup-keys/'
     dest: /tmp/backup-keys-import/
+    mode: push
     owner: no
     group: no
     perms: yes
@@ -133,29 +134,24 @@
       - '--no-motd'
       - '--quiet'
 
-- name: Import the backup encryption keys if they already exists
-  when: keys_restore.changed and backup.locations is defined and backup.locations != []
-  tags: sync
+- name: Initialise the repository, to test access and retrieve the key
+  when: backup.locations is defined and backup.locations != []
+  tags: backup
   shell: >-
-    test -f /tmp/backup-keys-import/{{ location.name }}.key &&
-    borg key import --info
-    {{ location.url | regex_replace("^[^:]+://", "") }}
-    /tmp/backup-keys-import/{{ location.name }}.key
-    || /bin/true
+    /usr/local/sbin/backup
+    --action init
+    --config {{ location.name }}
+    --import-key-path /tmp/backup-keys-import/{{ location.name }}.key
+    --export-key-path /tmp/backup-keys-export/{{ location.name }}.key
   with_items:
     - '{{ backup.locations }}'
   loop_control:
     loop_var: location
 
-- name: Retrieve the backup encryption keys
-  when: backup.locations is defined and backup.locations != []
+- name: Import the backup encryption keys if they already exists
+  when: keys_restore.changed and backup.locations is defined and backup.locations != []
   tags: sync
   shell: >-
-    borg key export
-    {{ location.url | regex_replace("^[^:]+://", "") }}
-    /tmp/backup-keys-export/{{ location.name }}.key
-  args:
-    creates: '/tmp/backup-keys-export/{{ location.name }}.key'
   with_items:
     - '{{ backup.locations }}'
   loop_control:

--- a/install/playbooks/roles/borg-backup/tasks/restore-all.yml
+++ b/install/playbooks/roles/borg-backup/tasks/restore-all.yml
@@ -57,6 +57,7 @@
     doveadm index -u {{ user.uid }} *
   with_items:
     - '{{ users }}'
+    - uid: postmaster
   loop_control:
     loop_var: user
 

--- a/install/playbooks/roles/borg-backup/templates/cron-backup-script.sh
+++ b/install/playbooks/roles/borg-backup/templates/cron-backup-script.sh
@@ -1,11 +1,8 @@
 #!/bin/dash
 
-# Log file path: per location
-log_file='/var/log/backup-{{ location.name }}.log'
-
 # Call the global script helper
 {% if system.debug %}
-/usr/local/sbin/backup --config '{{ location.name }}' --log-file "$log_file" --log-level DEBUG
+/usr/local/sbin/backup --config '{{ location.name }}' --log-level DEBUG
 {% else %}
-/usr/local/sbin/backup --config '{{ location.name }}' --log-file "$log_file"
+/usr/local/sbin/backup --config '{{ location.name }}'
 {% endif %}

--- a/install/playbooks/roles/borg-backup/templates/cron-check-script.sh
+++ b/install/playbooks/roles/borg-backup/templates/cron-check-script.sh
@@ -1,11 +1,8 @@
 #!/bin/dash
 
-# Log file path: per location
-log_file='/var/log/backup-check-{{ location.name }}.log'
-
 # Call the global script helper to verify the data
 {% if system.debug %}
-/usr/local/sbin/backup --action check-data --config '{{ location.name }}' --log-file "$log_file" --log-level DEBUG
+/usr/local/sbin/backup --action check-data --config '{{ location.name }}' --log-level DEBUG
 {% else %}
-/usr/local/sbin/backup --action check-data --config '{{ location.name }}' --log-file "$log_file"
+/usr/local/sbin/backup --action check-data --config '{{ location.name }}'
 {% endif %}

--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -272,3 +272,10 @@
   with_items:
     - '*.key'
     - '*.private'
+
+# Add extra records ===========================================================
+- name: Add extra records
+  when: bind.extra_records != []
+  template:
+    src: extra-records.conf
+    dest: /etc/homebox/dns-entries.d/90-extra-records.bind

--- a/install/playbooks/roles/dns-server-bind/templates/extra-records.conf
+++ b/install/playbooks/roles/dns-server-bind/templates/extra-records.conf
@@ -1,0 +1,6 @@
+{% if bind.extra_records != [] %}
+;; Additional records external to the server
+{% for record in bind.extra_records %}
+{{ "%-12s" | format(record.name) }} IN {{ "%-6s" | format(record.type) }} {{ record.ip }}
+{% endfor %}
+{% endif %}

--- a/install/playbooks/roles/system-prepare/tasks/main.yml
+++ b/install/playbooks/roles/system-prepare/tasks/main.yml
@@ -253,3 +253,8 @@
     src: yubikey-enroll.sh
     dest: /usr/local/sbin/yubikey-enroll.sh
     mode: 0700
+
+- name: Activate some aliases in bashrc
+  template:
+    src: bashrc
+    dest: /root/.bashrc

--- a/install/playbooks/roles/system-prepare/templates/bashrc
+++ b/install/playbooks/roles/system-prepare/templates/bashrc
@@ -1,0 +1,18 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+
+# Note: PS1 and umask are already set in /etc/profile. You should not
+# need this unless you want different defaults for root.
+# PS1='${debian_chroot:+($debian_chroot)}\h:\w\$ '
+# umask 022
+
+# You may uncomment the following lines if you want `ls' to be colorized:
+export LS_OPTIONS='--color=auto'
+eval "`dircolors`"
+alias ls='ls $LS_OPTIONS'
+alias ll='ls $LS_OPTIONS -lh'
+alias l='ls $LS_OPTIONS -lA'
+
+# Some more alias to avoid making mistakes:
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'


### PR DESCRIPTION
- Import / Export keys on repository creation
- Factorise subprocess.run
- Check if a repository has a key before importing one
- Add the configuration name as a suffix by default to the name of the
- log file
- CIFS: Add output firewall rules
- Allow rate limit
- Use weekly repository check by default