### PR TITLE
Default packages repository update

### DIFF
--- a/install/playbooks/roles/packages/templates/sources.list
+++ b/install/playbooks/roles/packages/templates/sources.list
@@ -1,14 +1,14 @@
 # Main repository
-deb http://httpredir.debian.org/debian/ stretch main non-free contrib
-deb-src http://httpredir.debian.org/debian/ stretch main non-free contrib
+deb http://deb.debian.org/debian/ stretch main non-free contrib
+deb-src http://deb.debian.org/debian/ stretch main non-free contrib
 
 deb http://security.debian.org/ stretch/updates main contrib non-free
 deb-src http://security.debian.org/ stretch/updates main contrib non-free
 
 # stretch-updates, previously known as 'volatile'
-deb http://httpredir.debian.org/debian/ stretch-updates main contrib non-free
-deb-src http://httpredir.debian.org/debian/ stretch-updates main contrib non-free
+deb http://deb.debian.org/debian/ stretch-updates main contrib non-free
+deb-src http://deb.debian.org/debian/ stretch-updates main contrib non-free
 
 # stretch-backports, previously on backports.debian.org
-deb http://httpredir.debian.org/debian/ stretch-backports main contrib non-free
-deb-src http://httpredir.debian.org/debian/ stretch-backports main contrib non-free
+deb http://deb.debian.org/debian/ stretch-backports main contrib non-free
+deb-src http://deb.debian.org/debian/ stretch-backports main contrib non-free

--- a/install/playbooks/roles/rspamd/handlers/main.yml
+++ b/install/playbooks/roles/rspamd/handlers/main.yml
@@ -1,10 +1,11 @@
+---
+
 - name: Restart rspamd
   service:
     name: rspamd
     state: restarted
 
 - name: Restart AppArmor service
-  tags: dovecot
   service:
     name: apparmor
     state: restarted

--- a/install/playbooks/roles/rspamd/tasks/main.yml
+++ b/install/playbooks/roles/rspamd/tasks/main.yml
@@ -7,19 +7,6 @@
     path: '{{ playbook_dir }}/../../backup/{{ network.domain }}/rspamd/'
     state: directory
 
-- name: Add rspamd GPG key
-  tags: rspamd
-  apt_key:
-    url: https://rspamd.com/apt-stable/gpg.key
-    state: present
-
-- name: Add rspamd repository
-  tags: rspamd
-  apt_repository:
-    repo: deb http://rspamd.com/apt-stable/ stretch main
-    state: present
-    filename: 'rspamd'
-
 - name: Install rspamd packages
   tags: rspamd
   vars:


### PR DESCRIPTION
- Use deb.debian.org (httpredir not maintained any more)
- Use Debian backports for rspamd