### PR TITLE
Use a custom name for the backup and restore script

### DIFF
--- a/install/playbooks/roles/borg-backup/tasks/main.yml
+++ b/install/playbooks/roles/borg-backup/tasks/main.yml
@@ -96,7 +96,7 @@
   tags: scripts
   copy:
     src: backup.py
-    dest: '/usr/local/sbin/backup'
+    dest: '/usr/local/sbin/homebox-backup'
     mode: '0700'
 
 - name: Create sync directories to import/export keys
@@ -138,7 +138,7 @@
   when: backup.locations is defined and backup.locations != []
   tags: backup
   shell: >-
-    /usr/local/sbin/backup
+    /usr/local/sbin/homebox-backup
     --action init
     --config {{ location.name }}
     --import-key-path /tmp/backup-keys-import/{{ location.name }}.key

--- a/install/playbooks/roles/borg-backup/tasks/restore-all.yml
+++ b/install/playbooks/roles/borg-backup/tasks/restore-all.yml
@@ -11,7 +11,7 @@
 - name: Restore /home and /var/backups folders from a previous installation
   tags: restore
   shell: >-
-    /usr/local/sbin/backup --action restore --config {{ location.name }}
+    /usr/local/sbin/homebox-backup --action restore --config {{ location.name }}
   with_items:
     - '{{ backup.locations | selectattr("restore", "defined") | selectattr("restore", "equalto", true) | list }}'
   loop_control:

--- a/install/playbooks/roles/borg-backup/templates/cron-backup-script.sh
+++ b/install/playbooks/roles/borg-backup/templates/cron-backup-script.sh
@@ -2,7 +2,7 @@
 
 # Call the global script helper
 {% if system.debug %}
-/usr/local/sbin/backup --config '{{ location.name }}' --log-level DEBUG
+/usr/local/sbin/homebox-backup --config '{{ location.name }}' --log-level DEBUG
 {% else %}
-/usr/local/sbin/backup --config '{{ location.name }}'
+/usr/local/sbin/homebox-backup --config '{{ location.name }}'
 {% endif %}

--- a/install/playbooks/roles/borg-backup/templates/cron-check-script.sh
+++ b/install/playbooks/roles/borg-backup/templates/cron-check-script.sh
@@ -2,7 +2,7 @@
 
 # Call the global script helper to verify the data
 {% if system.debug %}
-/usr/local/sbin/backup --action check-data --config '{{ location.name }}' --log-level DEBUG
+/usr/local/sbin/homebox-backup --action check-data --config '{{ location.name }}' --log-level DEBUG
 {% else %}
-/usr/local/sbin/backup --action check-data --config '{{ location.name }}'
+/usr/local/sbin/homebox-backup --action check-data --config '{{ location.name }}'
 {% endif %}


### PR DESCRIPTION
This should avoid clashes with other binaries called ‘backup’ on Debian.