### PR TITLE
Wait for the dpkg file to be unlocked before the first update

### DIFF
--- a/install/playbooks/roles/system-prepare/tasks/main.yml
+++ b/install/playbooks/roles/system-prepare/tasks/main.yml
@@ -1,5 +1,18 @@
 ---
 
+# This seems to happen with some cloud providers, the first time the server boots
+# Wait until no one locks the dpkg / apt loc file
+- name: Wait for apt to be unlocked
+  tags: apt
+  register: result
+  retries: 9
+  delay: 5
+  shell: >-
+    test -f /var/lib/dpkg/lock &&
+    fuser /var/lib/dpkg/lock 2>&1 ;
+    echo
+  until: result.stdout == ''
+
 # Install the most required packages
 - name: Update packages cache if older than 1h
   tags: apt
@@ -16,14 +29,8 @@
 
 - name: Upgrade the distribution
   tags: apt
-  register: result
-  retries: 3
-  delay: 15
   apt:
     upgrade: true
-  until: >-
-    result.stderr is not defined or
-    result.stderr == ''
 
 - name: Install required packages
   tags: apt


### PR DESCRIPTION
This should hopefully fix the random issues on packages repository updates with vultr