### PR TITLE
Debian releases specifics

### DIFF
--- a/install/playbooks/roles/borg-backup/tasks/main.yml
+++ b/install/playbooks/roles/borg-backup/tasks/main.yml
@@ -7,10 +7,22 @@
     state: latest
 
 - name: Install borgbackup package
+  when:
+    - ansible_facts['distribution'] == "Debian"
+    - ansible_facts['distribution_major_version'] == "9"
   tags: apt
   apt:
     name: borgbackup
     default_release: stretch-backports
+    state: latest
+
+- name: Install borgbackup package
+  when:
+    - ansible_facts['distribution'] == "Debian"
+    - ansible_facts['distribution_major_version']|int >= 10
+  tags: apt
+  apt:
+    name: borgbackup
     state: latest
 
 - name: Create the backups mount point root

--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -9,10 +9,23 @@
 
 # When IPv6 is used, bind9 should be taken from backports
 - name: Install the required packages
+  when:
+    - ansible_facts['distribution'] == "Debian"
+    - ansible_facts['distribution_major_version'] == "9"
   apt:
     name: '{{ bind_packages }}'
     state: present
     default_release: '{{ ipv6_used | ternary("stretch-backports", "stretch") }}'
+
+- name: Install the required packages
+  when:
+    - ansible_facts['distribution'] == "Debian"
+    - ansible_facts['distribution_major_version']|int >= 10
+  apt:
+    name:
+      - bind9
+      - dnsutils
+    state: present
 
 - name: Stop the DNS server before creating the configuration
   service:

--- a/install/playbooks/roles/packages/tasks/main.yml
+++ b/install/playbooks/roles/packages/tasks/main.yml
@@ -30,6 +30,22 @@
     name: apticron
     state: latest
 
+# Starting from Debian buster (10), /etc/apticron/apticron.conf is not
+# installed by default
+- name: Check if the apticron configuration file is present
+  register: apticron_conf_stat
+  stat:
+    path: /etc/apticron/apticron.conf
+
+# The default apticron.conf file is available in /usr/lib/apticron
+- name: Install distribution default configuration of apticron if not already present
+  tags: apt
+  when: apticron_conf_stat.stat.exists == False
+  copy:
+    remote_src: yes
+    src: /usr/lib/apticron/apticron.conf
+    dest: /etc/apticron/apticron.conf
+
 - name: Configure apticron to send email alerts
   tags: apt
   replace:

--- a/install/playbooks/roles/packages/templates/sources.list
+++ b/install/playbooks/roles/packages/templates/sources.list
@@ -1,14 +1,14 @@
 # Main repository
-deb http://deb.debian.org/debian/ stretch main non-free contrib
-deb-src http://deb.debian.org/debian/ stretch main non-free contrib
+deb http://deb.debian.org/debian/ {{ ansible_facts['distribution_release'] }} main non-free contrib
+deb-src http://deb.debian.org/debian/ {{ ansible_facts['distribution_release'] }} main non-free contrib
 
-deb http://security.debian.org/ stretch/updates main contrib non-free
-deb-src http://security.debian.org/ stretch/updates main contrib non-free
+deb http://security.debian.org/ {{ ansible_facts['distribution_release'] }}/updates main contrib non-free
+deb-src http://security.debian.org/ {{ ansible_facts['distribution_release'] }}/updates main contrib non-free
 
-# stretch-updates, previously known as 'volatile'
-deb http://deb.debian.org/debian/ stretch-updates main contrib non-free
-deb-src http://deb.debian.org/debian/ stretch-updates main contrib non-free
+# {{ ansible_facts['distribution_release'] }}-updates, previously known as 'volatile'
+deb http://deb.debian.org/debian/ {{ ansible_facts['distribution_release'] }}-updates main contrib non-free
+deb-src http://deb.debian.org/debian/ {{ ansible_facts['distribution_release'] }}-updates main contrib non-free
 
-# stretch-backports, previously on backports.debian.org
-deb http://deb.debian.org/debian/ stretch-backports main contrib non-free
-deb-src http://deb.debian.org/debian/ stretch-backports main contrib non-free
+# {{ ansible_facts['distribution_release'] }}-backports, previously on backports.debian.org
+deb http://deb.debian.org/debian/ {{ ansible_facts['distribution_release'] }}-backports main contrib non-free
+deb-src http://deb.debian.org/debian/ {{ ansible_facts['distribution_release'] }}-backports main contrib non-free

--- a/preseed/Dockerfile
+++ b/preseed/Dockerfile
@@ -1,5 +1,5 @@
 # Start from Debian stable (Stretch)
-FROM debian:stable
+FROM debian:stretch
 
 # Add backports repository
 RUN echo 'deb http://deb.debian.org/debian/ stretch-backports main contrib non-free' >>/etc/apt/sources.list


### PR DESCRIPTION
A few changes now that stretch is oldstable.

Concerns the apt source.list and backports, the preseed docker base image, and a change in apticron configuration handling in buster.