### PR TITLE
Use the uri module to get external IP addresses

### DIFF
--- a/install/playbooks/roles/remote-access/tasks/ufw-rules.yml
+++ b/install/playbooks/roles/remote-access/tasks/ufw-rules.yml
@@ -1,25 +1,18 @@
 ---
 
-- name: Install curl if not already installed
-  delegate_to: localhost
-  apt:
-    name: curl
-    state: present
-
 - name: Get the external IP address
   delegate_to: localhost
-  register: ext_ip
-  shell: >-
-    curl -s https://api.ipify.org/
-  args:
-    warn: false
+  register: ext_ip_api_response
+  uri:
+    url: https://api.ipify.org/
+    return_content: true
 
 - name: Make sure the external IP address is working as well
   tags: security
   ufw:
     proto: tcp
     port: 22
-    src: '{{ ext_ip.stdout }}'
+    src: '{{ ext_ip_api_response.content }}'
     rule: allow
     comment: Access SSH from the ansible host (IPv4)
 
@@ -27,18 +20,17 @@
 # address, the API returns the IPv4
 - name: Get the external IP address (IPv6)
   delegate_to: localhost
-  register: ext_ip6
-  shell: >-
-    curl -s https://api6.ipify.org/
-  args:
-    warn: false
+  register: ext_ip6_api_response
+  uri:
+    url: https://api6.ipify.org/
+    return_content: true
 
 - name: Make sure the external IP address is working as well
   tags: security
   ufw:
     proto: tcp
     port: 22
-    src: '{{ ext_ip6.stdout }}'
+    src: '{{ ext_ip6_api_response.content }}'
     rule: allow
     comment: Access SSH from the ansible host (IPv6)
 


### PR DESCRIPTION
Remove the dependency of curl on the ansible host. The user running
ansible-playbook might not have the right to install software, nor to
have apt mark it as manually installed if already present.