### PR TITLE
Fix dir backup urls examples

### DIFF
--- a/config/system-example.yml
+++ b/config/system-example.yml
@@ -181,7 +181,7 @@ users:
 
 # Exemple 1: backup on the local disk. Useful for small backup only
 #   - name: local
-#     url: dir://var/backups/homebox
+#     url: dir:///var/backups/homebox
 #     active: yes                      # The backup is currently active
 #     frequency: daily                 # Run the backup every day
 #     keep_daily: 3                    # Keep the last three days locally

--- a/docs/backup-home.md
+++ b/docs/backup-home.md
@@ -77,7 +77,7 @@ This can be a temporary solution unless your main homebox drive is mounted in RA
 backup:
   ...
   - name: local
-    url: dir://var/backups/homebox
+    url: dir:///var/backups/homebox
     active: yes
     frequency: daily
     keep_daily: 7

--- a/install/playbooks/roles/borg-backup/tasks/install-protocol-dir.yml
+++ b/install/playbooks/roles/borg-backup/tasks/install-protocol-dir.yml
@@ -41,6 +41,6 @@
     line: '{{ line }}'
   with_items:
     - "# Exclude '{{ location.name }}' backup directory"
-    - 'pp:{{ location.url | replace("dir:/", "") }}/'
+    - 'pp:{{ location.url | urlsplit("path") }}/'
   loop_control:
     loop_var: line


### PR DESCRIPTION
Use dir:///var/backups/homebox for the location to be the absolute path
/var/backups/homebox when processed by backup.py.