### PR TITLE
Test sending mail to postmaster if only one user

### DIFF
--- a/tests/playbooks/roles/postfix/tasks/check-extension-email.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-extension-email.yml
@@ -19,7 +19,7 @@
   shell: >-
     swaks
     --from="{{ users[0].mail }}"
-    --to "{{ users[1].mail | regex_replace('@', '+lists@') }}"
+    --to "{{ 'postmaster+lists@' ~ network.domain if users|count < 2 else users[1].mail | regex_replace('@', '+lists@') }}"
     --h-Subject '{{ test_subject }}'
     --auth
     --auth-user="{{ user0_uid }}"
@@ -35,7 +35,7 @@
   register: email_found
   shell: >-
     grep -l "Subject: {{ test_subject }}"
-    /home/users/{{ users[1].uid }}/mails/maildir/new/*
+    /home/users/{{ 'postmaster' if users|count < 2 else users[1].uid }}/mails/maildir/new/*
   until: email_found.rc == 0
   retries: 10
   delay: 2

--- a/tests/playbooks/roles/postfix/tasks/check-simple-email.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-simple-email.yml
@@ -19,7 +19,7 @@
   shell: >-
     swaks
     --from="{{ users[0].mail }}"
-    --to "{{ users[1].mail }}"
+    --to "{{ 'postmaster@' ~ network.domain if users|count < 2 else users[1].mail }}"
     --h-Subject '{{ test_subject }}'
     --auth
     --auth-user="{{ user0_uid }}"
@@ -35,7 +35,7 @@
   register: email_found
   shell: >-
     grep -l "Subject: {{ test_subject }}"
-    /home/users/{{ users[1].uid }}/mails/maildir/new/*
+    /home/users/{{ 'postmaster' if users|count < 2 else users[1].uid }}/mails/maildir/new/*
   until: email_found.rc == 0
   retries: 10
   delay: 2

--- a/tests/playbooks/roles/postfix/tasks/check-utf8-email.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-utf8-email.yml
@@ -19,7 +19,7 @@
   shell: >-
     swaks
     --from="{{ users[0].mail }}"
-    --to "{{ users[1].aliases[0] }}"
+    --to "{{ 'hostmaster@' ~ network.domain if users|count < 2 else users[1].aliases[0] }}"
     --h-Subject '{{ test_subject }}'
     --auth
     --auth-user="{{ user0_uid }}"
@@ -35,7 +35,7 @@
   register: email_found
   shell: >-
     grep -l "Subject: {{ test_subject }}"
-    /home/users/{{ users[1].uid }}/mails/maildir/new/*
+    /home/users/{{ 'postmaster' if users|count < 2 else users[1].uid }}/mails/maildir/new/*
   until: email_found.rc == 0
   retries: 10
   delay: 2


### PR DESCRIPTION
Avoid tests failing on "list object has no element 1" if only one user
is defined.

Could be completed to have postmaster send email to itself if no user is
configured at all.