### PR TITLE
Use dhclient options to handle /etc/resolv.conf

### DIFF
--- a/install/playbooks/roles/system-cleanup/tasks/network-bind.yml
+++ b/install/playbooks/roles/system-cleanup/tasks/network-bind.yml
@@ -14,13 +14,6 @@
     src: resolv.conf
     dest: /etc/resolv.conf
 
-- name: deploy the template to update resolv.conf
-  template:
-    src: homebox-dhclient-hook.sh
-    dest: /etc/dhcp/dhclient-exit-hooks.d/homebox-dhclient-hook.sh
-    mode: 0755
-
-
 # Check if a DHCP client is installed. In this case,
 # make sure it is not querying the external DNS servers
 - name: Check if dhclient is installed

--- a/install/playbooks/roles/system-cleanup/templates/dhclient.conf
+++ b/install/playbooks/roles/system-cleanup/templates/dhclient.conf
@@ -1,15 +1,23 @@
 # Configuration file for /sbin/dhclient.
-# This is a simplified configuration for homebox, that is
-# used to avoid overwriting DNS servers in /etc/resolv.conf
-# The options 'domain-name-servers' and 'dhcp6.name-servers' have been removed
-# The rest is unchanged. This is compatible with Debian buster version of
-# the same file, that has not changed between the versions
+# This is a configuration for homebox, that is used to avoid overwriting DNS
+# servers in /etc/resolv.conf.
+# The requested options are unchanged. This is compatible with Debian buster
+# version of the same file, that has not changed between the versions
 
 option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
 
 send host-name = gethostname();
 request subnet-mask, broadcast-address, time-offset, routers,
-        domain-name, domain-search, host-name,
-        dhcp6.domain-search, dhcp6.fqdn, dhcp6.sntp-servers,
+        domain-name, domain-name-servers, domain-search, host-name,
+        dhcp6.name-servers, dhcp6.domain-search, dhcp6.fqdn, dhcp6.sntp-servers,
         netbios-name-servers, netbios-scope, interface-mtu,
         rfc3442-classless-static-routes, ntp-servers;
+
+prepend domain-name-servers 127.0.0.1;
+supersede domain-search "{{ network.domain }}";
+supersede domain-name "{{ network.domain }}";
+
+supersede host-name "{{ network.hostname|splitext|first }}"
+
+prepend dhcp6.name-servers ::1;
+supersede dhcp6.domain-search "{{ network.domain }}";

--- a/install/playbooks/roles/system-cleanup/templates/homebox-dhclient-hook.sh
+++ b/install/playbooks/roles/system-cleanup/templates/homebox-dhclient-hook.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-cat << end > /etc/resolv.conf
-# Use the internal bind server
-nameserver 127.0.0.1
-end

--- a/install/playbooks/roles/system-cleanup/templates/resolv.conf
+++ b/install/playbooks/roles/system-cleanup/templates/resolv.conf
@@ -1,3 +1,4 @@
 # Use the internal bind server
+domain {{ network.domain }}
 search {{ network.domain }}
 nameserver 127.0.0.1


### PR DESCRIPTION
Use the default list of requested options from the Debian package and
use prepend and supersede modifiers. The modifiers are only used if the
corresponding option is received via DHCP.

- Prepend for domain-name-servers and dhcp6.name-servers.

  Allows to use localhost but also have the network configured DNS
  server as backup in case bind is down.

- Supersede for domain-search, domain-name, host-name,
  dhcp6.name-servers and dhcp6.domain-search.

  Allows to ignore these network sent parameters, eg. we do not want to
  have the dhclient-script overwriting our hostname.

  The configured domain is network.domain, the configured hostname is
  deduced from the first part of network.hostname.

Remove the homebox-dhclient-hook.sh.