### PR TITLE
Add ssh_disable_users_access_with_password option

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -255,10 +255,11 @@ firewall_default:
 # Extra security values
 security_default:
   auto_update: true                             # Install security updates automatically, using unattended-upgrades
-  ssh_disable_root_access_with_password: true   # Force SSH authentication to use public / private key
+  ssh_disable_root_access_with_password: true   # Force SSH authentication to use public / private key for root
   ssh_disable_root_access: false                # At the end of the installation, completely disable remote
                                                 # root access via SSH and force the use of sudo for the administrators
   lock_root_password: true                      # Disable console root access by locking root password.
+  ssh_disable_users_access_with_password: false # Force SSH authentication to use public / private key for all users
   alerts_email:
     - 'admin@{{ network.domain }}'
   # various options when luks is installed

--- a/install/playbooks/roles/remote-access/tasks/main.yml
+++ b/install/playbooks/roles/remote-access/tasks/main.yml
@@ -19,3 +19,13 @@
     name: root
     password_lock: '{{ security.lock_root_password }}'
 
+- name: Remove users password access from SSH
+  when: security.ssh_disable_users_access_with_password
+  tags: security
+  notify: Restart SSH
+  replace:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?PasswordAuthentication yes.*'
+    replace: 'PasswordAuthentication no'
+    mode: 0600
+


### PR DESCRIPTION
Force SSH authentication to use public / private key for all users if
security.ssh_disable_users_access_with_password is true.

Configured during remote access setup.

The default value is set to false.