### PR TITLE
Conditional installation of external ip check scripts

### DIFF
--- a/common/roles/external-ip-type/tasks/auto-ip.yml
+++ b/common/roles/external-ip-type/tasks/auto-ip.yml
@@ -4,34 +4,26 @@
 
 - name: Get the external IP address automatically
   tags: facts
-  get_url:
-    url: https://api.ipify.org?format=text
-    dest: /tmp/external_ip.txt
-
-- name: Read the IP address detected
   register: external_ip_facts
-  tags: facts
-  shell: "cat /tmp/external_ip.txt"
+  uri:
+    url: https://api.ipify.org?format=text
+    return_content: yes
 
 - name: Store the IP address detected
   tags: facts
   set_fact:
-    external_ip: '{{ external_ip_facts.stdout }}'
+    external_ip: '{{ external_ip_facts.content }}'
 
 # Backup IP address (backup_ip / IPv6)
 - name: Get the backup IP address automatically
   tags: facts
-  get_url:
-    url: https://api6.ipify.org?format=text
-    dest: /tmp/backup_ip.txt
-
-- name: Read the backup IP address detected
   register: backup_ip_facts
-  tags: facts
-  shell: "cat /tmp/backup_ip.txt"
+  uri:
+    url: https://api6.ipify.org?format=text
+    return_content: yes
 
 - name: Store the backup IP address detected (if different from the first one)
-  when: backup_ip_facts.stdout != external_ip
+  when: backup_ip_facts.content != external_ip
   tags: facts
   set_fact:
-    backup_ip: '{{ backup_ip_facts.stdout }}'
+    backup_ip: '{{ backup_ip_facts.content }}'

--- a/common/roles/external-ip-type/tasks/main.yml
+++ b/common/roles/external-ip-type/tasks/main.yml
@@ -8,11 +8,11 @@
 # Get the external IP address automatically first
 
 - name: Get the external IP address automatically
-  when: network.auto_detect_ip == "auto"
+  when: network.auto_detect_ip
   include_tasks: auto-ip.yml
 
 - name: Get the external IP address automatically
-  when: network.auto_detect_ip != "auto"
+  when: not network.auto_detect_ip
   include_tasks: manual-ip.yml
 
 # Detect the main IP address type (IPv4 or IPv6)

--- a/common/roles/external-ip-type/tasks/main.yml
+++ b/common/roles/external-ip-type/tasks/main.yml
@@ -31,7 +31,7 @@
 
 # Detect the backup IP address type (IPv4 or IPv6)
 - name: Set backup IP address type (A or AAAA)
-  when: network.backup_ip != None
+  when: backup_ip is defined and backup_ip != ""
   tags: facts
   register: backup_ip_type
   shell:
@@ -41,7 +41,7 @@
 
 - name: Set backup IP address type (A or AAAA)
   tags: facts
-  when: network.backup_ip != None
+  when: backup_ip is defined and backup_ip != ""
   set_fact:
     backup_ip_type: '{{ backup_ip_type.stdout }}'
 

--- a/install/playbooks/main.yml
+++ b/install/playbooks/main.yml
@@ -9,6 +9,7 @@
 # and set up remote access
 - import_playbook: system-prepare.yml
 - import_playbook: external-ip.yml
+  when: network.auto_detect_ip == "auto"
 - import_playbook: remote-access.yml
 
 # Install fwknop (Single Packet Authorization)

--- a/install/playbooks/main.yml
+++ b/install/playbooks/main.yml
@@ -9,7 +9,7 @@
 # and set up remote access
 - import_playbook: system-prepare.yml
 - import_playbook: external-ip.yml
-  when: network.auto_detect_ip == "auto"
+  when: network.auto_detect_ip
 - import_playbook: remote-access.yml
 
 # Install fwknop (Single Packet Authorization)

--- a/install/playbooks/roles/dns-server-bind-refresh/meta/main.yml
+++ b/install/playbooks/roles/dns-server-bind-refresh/meta/main.yml
@@ -2,4 +2,4 @@
 
 dependencies:
   - { role: load-defaults, when: defaults_loaded is not defined }
-  - { role: external-ip }
+  - { role: external-ip-type }

--- a/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Copy DNS entries in bind cache directory (backup IP)
   notify: Restart bind
-  when: backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   copy:
     src: '/etc/bind/{{ file }}'
     dest: '/var/cache/bind/{{ file }}'

--- a/install/playbooks/roles/dns-server-bind/meta/main.yml
+++ b/install/playbooks/roles/dns-server-bind/meta/main.yml
@@ -2,5 +2,4 @@
 
 dependencies:
   - { role: load-defaults, when: defaults_loaded is not defined }
-  - { role: external-ip }
   - { role: external-ip-type }

--- a/install/playbooks/roles/dns-server-bind/tasks/build-ip-info.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/build-ip-info.yml
@@ -16,7 +16,7 @@
 
 # Backup IP address
 - name: Build reverse IP address using shell
-  when: network.backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   shell: >-
     dig -x {{ network.backup_ip }}
     @{{ bind.forward[0] }}
@@ -25,7 +25,7 @@
   register: reverse_backup_ip
 
 - name: Build the reverse IP address (works for IPv4 or IPv6)
-  when: network.backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   tags: facts
   set_fact:
     reverse_backup_ip: "{{ reverse_backup_ip.stdout }}"

--- a/install/playbooks/roles/dns-server-bind/tasks/build-ip-info.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/build-ip-info.yml
@@ -14,17 +14,6 @@
   set_fact:
     reverse_ip: "{{ reverse_main_ip.stdout }}"
 
-- name: Set external IP address type (A or AAAA)
-  register: main_ip_type
-  shell:
-    echo {{ external_ip }}
-    | grep -E '^[0-9\.]+$' 2>&1 >/dev/null
-    && echo A || echo AAAA
-
-- name: Set external IP address type (A or AAAA)
-  set_fact:
-    external_ip_type: '{{ (main_ip_type.stdout) }}'
-
 # Backup IP address
 - name: Build reverse IP address using shell
   when: network.backup_ip is defined
@@ -40,16 +29,3 @@
   tags: facts
   set_fact:
     reverse_backup_ip: "{{ reverse_backup_ip.stdout }}"
-
-- name: Set external IP address type (A or AAAA)
-  when: network.backup_ip is defined
-  register: backup_ip_type
-  shell:
-    echo {{ network.backup_ip }}
-    | grep -E '^[0-9\.]+$' 2>&1 >/dev/null
-    && echo A || echo AAAA
-
-- name: Set external IP address type (A or AAAA)
-  when: network.backup_ip is defined
-  set_fact:
-    backup_ip_type: '{{ (backup_ip_type.stdout) }}'

--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -53,7 +53,7 @@
     loop_var: file
 
 - name: Copy the configuration template
-  when: backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   tags: config
   vars:
     serial: "{{ lookup('pipe', 'date +%s') }}"
@@ -224,7 +224,7 @@
     loop_var: file
 
 - name: Copy DNS entries in bind cache directory (backup IP)
-  when: backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   copy:
     src: '/etc/bind/{{ file }}'
     dest: '/var/cache/bind/{{ file }}'
@@ -248,7 +248,7 @@
     line: '127.0.0.1    main.{{ network.domain }}'
 
 - name: Ensure the backup record resolves to me
-  when: backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   tags: hosts
   lineinfile:
     path: /etc/hosts

--- a/install/playbooks/roles/dns-server-check-entries/meta/main.yml
+++ b/install/playbooks/roles/dns-server-check-entries/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 
 dependencies:
-  - { role: external-ip }
+  - { role: external-ip-type }

--- a/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
@@ -12,7 +12,7 @@
 # This is checking that the DNS server has been fully propagated
 - name: Check DNS propagation for backup IP address
   register: backup_ip_check
-  when: network.backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   shell: >-
     host backup.{{ network.domain }}
   retries: '{{ bind.propagation.retries | default(10) }}'

--- a/install/playbooks/roles/dovecot/meta/main.yml
+++ b/install/playbooks/roles/dovecot/meta/main.yml
@@ -2,4 +2,5 @@
 
 dependencies:
   - { role: load-defaults, when: defaults_loaded is not defined }
-  - { role: external-ip }
+  - { role: external-ip-type }
+  - { role: external-ip, when: access_check.active }

--- a/install/playbooks/roles/dovecot/templates/40-dovecot.bind
+++ b/install/playbooks/roles/dovecot/templates/40-dovecot.bind
@@ -1,12 +1,12 @@
 ;; SMTP server IP address, MX should point to a proper A record
 imap    IN       {{ "%-4s" | format(external_ip_type) }}      {{ external_ip }}
-{% if backup_ip is defined %}
+{% if backup_ip is defined and backup_ip != "" %}
 imap    IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 {% endif %}
 
 {% if mail.pop3 %}
 pop3    IN       {{ "%-4s" | format(external_ip_type) }}      {{ external_ip }}
-{% if backup_ip is defined %}
+{% if backup_ip is defined and backup_ip != "" %}
 pop3    IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 {% endif %}
 {% endif %}

--- a/install/playbooks/roles/ejabberd/meta/main.yml
+++ b/install/playbooks/roles/ejabberd/meta/main.yml
@@ -2,4 +2,4 @@
 
 dependencies:
   - { role: load-defaults, when: defaults_loaded is not defined }
-  - { role: external-ip }
+  - { role: external-ip-type }

--- a/install/playbooks/roles/ejabberd/templates/50-jabber.bind
+++ b/install/playbooks/roles/ejabberd/templates/50-jabber.bind
@@ -1,6 +1,6 @@
 ;; XMPP Server IP address, should be an A/AAAA record
 xmpp    IN       {{ "%-4s" | format(external_ip_type) }}      {{ external_ip }}
-{% if backup_ip is defined %}
+{% if backup_ip is defined and backup_ip != "" %}
 xmpp    IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 {% endif %}
 

--- a/install/playbooks/roles/external-ip/tasks/main.yml
+++ b/install/playbooks/roles/external-ip/tasks/main.yml
@@ -32,7 +32,7 @@
     hour: '0'
     minute: '0'
     name: External IP check
-    job: /usr/local/bin/external-ip-check '{{ network.external_ip }}'
+    job: /usr/local/bin/external-ip-check "$(grep EXTERNAL_IP /etc/homebox/external-ip | cut -f 2 -d '=')"
     cron_file: external-ip-check
     user: root
 
@@ -41,57 +41,3 @@
     /usr/local/bin/external-ip-check
   args:
     creates: /etc/homebox/external-ip
-
-- name: Run the script to get the external IP address automatically
-  tags: facts
-  when: network.external_ip == "auto"
-  register: external_ip_facts
-  shell: /usr/local/bin/external-ip -u /etc/external-ip.conf
-
-- name: Get the external IP address automatically
-  tags: facts
-  when: network.external_ip == "auto"
-  set_fact:
-    external_ip: '{{ external_ip_facts.stdout }}'
-
-- name: Get the external IP address automatically
-  tags: facts
-  when: network.external_ip != "auto"
-  set_fact:
-    external_ip: '{{ network.external_ip }}'
-
-- name: Set external IP address type (A or AAAA)
-  tags: facts
-  register: main_ip_type
-  shell:
-    echo {{ external_ip }}
-    | grep -E '^[0-9\.]+$' 2>&1 >/dev/null
-    && echo A || echo AAAA
-  changed_when: false
-
-- name: Set external IP address type (A or AAAA)
-  tags: facts
-  set_fact:
-    external_ip_type: '{{ (main_ip_type.stdout) }}'
-
-- name: Get the backup IP address
-  when: network.backup_ip != None
-  tags: facts
-  set_fact:
-    backup_ip: '{{ network.backup_ip }}'
-
-- name: Set external IP address type (A or AAAA)
-  when: network.backup_ip != None
-  tags: facts
-  register: backup_ip_type
-  shell:
-    echo {{ backup_ip }}
-    | grep -E '^[0-9\.]+$' 2>&1 >/dev/null
-    && echo A || echo AAAA
-  changed_when: false
-
-- name: Set external IP address type (A or AAAA)
-  tags: facts
-  when: network.backup_ip != None
-  set_fact:
-    backup_ip_type: '{{ (backup_ip_type.stdout) }}'

--- a/install/playbooks/roles/postfix/meta/main.yml
+++ b/install/playbooks/roles/postfix/meta/main.yml
@@ -2,4 +2,4 @@
 
 dependencies:
   - { role: load-defaults, when: defaults_loaded is not defined }
-  - { role: external-ip }
+  - { role: external-ip-type }

--- a/install/playbooks/roles/sogo/meta/main.yml
+++ b/install/playbooks/roles/sogo/meta/main.yml
@@ -2,4 +2,4 @@
 
 dependencies:
   - { role: load-defaults, when: defaults_loaded is not defined }
-  - { role: external-ip }
+  - { role: external-ip-type }


### PR DESCRIPTION
Let the playbooks depend on the common/roles/external-ip-type to determine external_ip(_type) and backup_ip(_type).

Simplify the install/playbooks/roles/external-ip to only install the external-ip-check scripts.

Install the external-ip-check scripts only if network.auto_detect_ip is true.

Maybe the playbook and role "external-ip" could be renamed to something like "external-ip-check-scripts" (maybe a bit long :sweat_smile:) to avoid confusion with the common "external-ip-type" ?