### PR TITLE
Allow configuration of a custom SPF record

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -445,6 +445,9 @@ bind_default:
   #     priority: 10
   #   - fqdn: fb.mail.gandi.net
   #     priority: 50
+  # SPF: allow for a custom SPF record.
+  # By default, recommend strict checks on the MX DNS records of the domain.
+  spf: "v=spf1 mx -all"
   # List of trusted servers to accept cache / recursive queries
   trusted:
     - src: 192.168.0.0/16

--- a/install/playbooks/roles/postfix/templates/30-postfix.bind
+++ b/install/playbooks/roles/postfix/templates/30-postfix.bind
@@ -16,8 +16,8 @@ _submission._tcp 3600 IN SRV 0 0 {{ mail.postfix.submission.port }} smtp.{{ netw
 _submission._tcp 3600 IN SRV 0 0 {{ mail.postfix.submission.port }} smtp2.{{ network.domain }}.
 {% endif %}
 
-;; SPF record: include all MX records
-@       IN       TXT    "v=spf1 mx -all"
+;; Strict SPF record
+@       IN       TXT    "{{ bind.spf }}"
 
 {% if bind.mx_backup != [] %}
 ;; Backup records if the server is unreachable


### PR DESCRIPTION
By adding an option in the bind_default section.