### PR TITLE
Allow configuration of secondary nameservers

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -431,6 +431,16 @@ bind_default:
   expire: 3600000         # 10000 hours
   neg_cache_ttl: 172800   # 2 days
   ttl: 3600               # 1 hour
+  # List of secondary nameservers.
+  # These servers will be announced as additionnal nameservers and allowed by
+  # IP address to request transfers from the server (AXFR requests).
+  # The default is the empty list, which disallow zone transfers by default.
+  ns_backup: []
+  # Example of record for gandi.net's secondary nameserver
+  # ns_backup:
+  #   - fqdn: ns6.gandi.net
+  #     ip: 217.70.177.40
+  # https://docs.gandi.net/en/domain_names/advanced_users/secondary_nameserver.html
   # General MX configuration
   mx_priority: 10
   # List of backup MX records. If the server is unreachable,

--- a/install/playbooks/roles/dns-server-bind/templates/forward-head
+++ b/install/playbooks/roles/dns-server-bind/templates/forward-head
@@ -17,6 +17,10 @@ main    IN      {{ "%-4s" | format(external_ip_type) }}    {{ external_ip }}
 backup  IN      {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 {% endif %}
 
+{% for secondary in bind.ns_backup %}
+@       IN      NS      {{ secondary.fqdn }}.
+{% endfor %}
+
 ;; Main record(s) for where everything goes by default
 @       IN      {{ "%-4s" | format(external_ip_type) }}    {{ external_ip }}
 {% if backup_ip is defined and backup_ip != "" %}

--- a/install/playbooks/roles/dns-server-bind/templates/named.conf.options
+++ b/install/playbooks/roles/dns-server-bind/templates/named.conf.options
@@ -152,7 +152,13 @@ options {
     allow-query-cache { trusted; };
 
     # Disallow transfers by default
-    allow-transfer { "none"; }
+    allow-transfer {
+{% for secondary in bind.ns_backup %}
+        {{ secondary.ip }};
+{% else %}
+        "none";
+{% endfor %}
+    };
 
     //========================================================================
     // If BIND logs error messages about the root key being expired,

--- a/install/playbooks/roles/dns-server-bind/templates/named.conf.options
+++ b/install/playbooks/roles/dns-server-bind/templates/named.conf.options
@@ -151,6 +151,9 @@ options {
     allow-recursion { trusted; };
     allow-query-cache { trusted; };
 
+    # Disallow transfers by default
+    allow-transfer { "none"; }
+
     //========================================================================
     // If BIND logs error messages about the root key being expired,
     // you will need to update your keys.  See https://www.isc.org/bind-keys


### PR DESCRIPTION
Disallow zone transfers by default in bind.

Allow for configuration of secondary servers: NS records and allow-transfer match entries by IP address.