### PR TITLE
Fixed wrong nginx template when certificate has no alias

### DIFF
--- a/install/playbooks/roles/certificates/templates/nginx-cert.conf
+++ b/install/playbooks/roles/certificates/templates/nginx-cert.conf
@@ -6,7 +6,7 @@ server {
     listen 80;
     listen [::]:80;
 
-{% if domain_alias == None %}
+{% if not domain_alias %}
     server_name {{ certificate_fqdn }};
 {% else %}
     server_name {{ certificate_fqdn }} {{ domain_alias + "." + network.domain }};


### PR DESCRIPTION
This would have affected dev branch only, but pretty annoying.
I should remember, from now on, the Ansible / Python way to test for None, empty strings, etc.