### PR TITLE
Determine dpkg lock with ls

### DIFF
--- a/install/playbooks/roles/system-prepare/tasks/main.yml
+++ b/install/playbooks/roles/system-prepare/tasks/main.yml
@@ -9,7 +9,7 @@
   delay: 5
   shell: >-
     test -f /var/lib/dpkg/lock &&
-    fuser /var/lib/dpkg/lock 2>&1 ;
+    ls -l /proc/*/fd/* 2>/dev/null | grep '/var/lib/dpkg/lock' ;
     echo
   until: result.stdout == ''
 


### PR DESCRIPTION
Remove dependency on fuser.

The minimal image I am installing on does not have fuser :sweat_smile: