### PR TITLE
Fix the hostname short name in dhclient.conf

### DIFF
--- a/install/playbooks/roles/system-cleanup/templates/dhclient.conf
+++ b/install/playbooks/roles/system-cleanup/templates/dhclient.conf
@@ -17,7 +17,7 @@ prepend domain-name-servers 127.0.0.1;
 supersede domain-search "{{ network.domain }}";
 supersede domain-name "{{ network.domain }}";
 
-supersede host-name "{{ network.hostname|splitext|first }}"
+supersede host-name "{{ network.hostname.split('.') | first }}"
 
 prepend dhcp6.name-servers ::1;
 supersede dhcp6.domain-search "{{ network.domain }}";


### PR DESCRIPTION
The "splitext" filter is for filenames and file extensions.

The "split" function is more generic.