### PR TITLE
Default domain_alias to undefined for certificates

### DIFF
--- a/install/playbooks/roles/certificates/tasks/gencert.yml
+++ b/install/playbooks/roles/certificates/tasks/gencert.yml
@@ -10,13 +10,6 @@
     port: 80
     comment: Allow LetsEncrypt temporarily
 
-# Add alerternative names if defined
-- name: Add the domain alias
-  when: domain_alias is defined and domain_alias != ""
-  tags: cert
-  set_fact:
-    domain_alias_cmd: '{{ "-d " + domain_alias + "." + network.domain }}'
-
 # The certbot package need to be installed
 - name: Create the certificate
   tags: cert
@@ -26,7 +19,7 @@
     --webroot
     --webroot-path "{{ site_root }}"
     --domain "{{ certificate_fqdn }}"
-    {{ domain_alias_cmd | default("") }}
+    {{ "-d " + domain_alias + "." + network.domain if domain_alias is defined and domain_alias != "" else "" }}
     --email "admin@{{ network.domain }}"
     {{ domain_alias_cmd is defined | ternary("--expand", "") }}
     {{ system.devel | ternary("--test-cert", "") }}


### PR DESCRIPTION
Avoid certificates getting a domain_alias from a previous run of the
certificate role.

Move certificate specific variables from playbook variables to role
parameters. Role parameters take precedence over facts set during
previous runs of the same role with different parameters ([Variable
precedence]).

If the domain_alias is not specified as a role parameter, the
certificate role will use the domain_alias fact set during gencert.yml
by the previous certificate role using one (eg. smtp2 from
cert-smtp.yml).

Configure "domain_alias: ~" in every playbook not using a domain_alias
for the requested certificates.

[Variable precedence]: https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable