### PR TITLE
POP3 disabled by default

### DIFF
--- a/install/playbooks/roles/autoconfig/templates/config-v1.1.xml
+++ b/install/playbooks/roles/autoconfig/templates/config-v1.1.xml
@@ -22,6 +22,7 @@
       <authentication>password-cleartext</authentication>
     </incomingServer>
 
+{% if mail.pop3 %}
     <!-- POP3 -->
     <incomingServer type="pop3">
       <hostname>pop3.{{ network.domain }}</hostname>
@@ -38,6 +39,7 @@
       <authentication>password-cleartext</authentication>
     </incomingServer>
 
+{% endif %}
     <!-- SMTP: Submission only -->
     <outgoingServer type="smtp">
       <hostname>smtp.{{ network.domain }}</hostname>

--- a/install/playbooks/roles/autodiscover/templates/autodiscover.xml
+++ b/install/playbooks/roles/autodiscover/templates/autodiscover.xml
@@ -13,6 +13,7 @@
     <SSL>on</SSL>
     <AuthRequired>on</AuthRequired>
   </Protocol>
+{% if mail.pop3 %}
   <Protocol>
     <Type>POP3</Type>
     <Server>pop3.{{ network.domain }}</Server>
@@ -22,6 +23,7 @@
     <SSL>on</SSL>
     <AuthRequired>on</AuthRequired>
   </Protocol>
+{% endif %}
   <Protocol>
     <Type>SMTP</Type>
     <Server>smtp.{{ network.domain }}</Server>

--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -176,12 +176,25 @@
       port: 143
     - comment: Allow IMAPS access
       port: 993
+    - comment: Allow Managesieve access
+      port: 4190
+  loop_control:
+    loop_var: rule
+
+- name: Configure the firewall for POP3 access
+  when: mail.pop3
+  tags: security
+  ufw:
+    rule: allow
+    proto: tcp
+    src: any
+    port: '{{ rule.port }}'
+    comment: '{{ rule.comment }}'
+  with_items:
     - comment: Allow POP3 access
       port: 110
     - comment: Allow POP3S access
       port: 995
-    - comment: Allow Managesieve access
-      port: 4190
   loop_control:
     loop_var: rule
 

--- a/install/playbooks/roles/dovecot/templates/40-dovecot.bind
+++ b/install/playbooks/roles/dovecot/templates/40-dovecot.bind
@@ -15,5 +15,12 @@ pop3    IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 ;; RFC 6186 entries, should point to an "A" record
 _imap._tcp 3600 IN SRV 10 0 143 imap.{{ network.domain }}.
 _imaps._tcp 3600 IN SRV 10 0 993 imap.{{ network.domain }}.
+{% if mail.pop3 %}
 _pop3._tcp 3600 IN SRV 20 0 110 pop3.{{ network.domain }}.
 _pop3s._tcp 3600 IN SRV 20 0 995 pop3.{{ network.domain }}.
+{% else %}
+;; POP3 and POP3S are not available
+;; https://tools.ietf.org/html/rfc6186#section-3.4
+_pop3._tcp 3600 IN SRV 0 0 0 .
+_pop3s._tcp 3600 IN SRV 0 0 0 .
+{% endif %}

--- a/install/playbooks/roles/dovecot/templates/conf.d/10-master.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/10-master.conf
@@ -38,17 +38,23 @@ service imap-login {
   #vsz_limit = $default_vsz_limit
 }
 
-{% if mail.pop3 %}
 service pop3-login {
   inet_listener pop3 {
+{% if mail.pop3 %}
     port = 110
+{% else %}
+    port = 0
+{% endif %}
   }
   inet_listener pop3s {
+{% if mail.pop3 %}
     port = 995
+{% else %}
+    port = 0
+{% endif %}
     ssl = yes
   }
 }
-{% endif %}
 
 service lmtp {
   unix_listener /var/spool/postfix/private/dovecot-lmtp {

--- a/tests/playbooks/mail-certificates.yml
+++ b/tests/playbooks/mail-certificates.yml
@@ -18,7 +18,8 @@
     certificate:
       type: pop3
   roles:
-    - certificate
+    - role: certificate
+      when: mail.pop3
 
 - hosts: homebox
   vars_files:


### PR DESCRIPTION
Following e8e3d2a, the POP3 services were not really disabled. If the `dovecot-pop3d` packages is installed, it seems inet listeners with `port=0` are required to disable the services (see commit description).

Also take care of the firewall rules configuration.

There is a newline added in the `40-dovecot.bind` file. I will propose a change to add missing newlines at end of files, but if you can merge this one first that would be great.
