### PR TITLE
Postfix configuration

### DIFF
--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -62,6 +62,12 @@
   set_fact:
     message_size_limit: '{{ 1024 + mail.max_attachment_size * 1394606 | int }}'
 
+- name: Copy the template for /etc/mailname for completeness (not used by configuration)
+  tags: config
+  template:
+    src: mailname
+    dest: /etc/mailname
+
 - name: Copy configuration template
   tags: config
   notify: Restart postfix

--- a/install/playbooks/roles/postfix/templates/mailname
+++ b/install/playbooks/roles/postfix/templates/mailname
@@ -1,0 +1,1 @@
+{{ network.domain }}

--- a/install/playbooks/roles/postfix/templates/main.cf
+++ b/install/playbooks/roles/postfix/templates/main.cf
@@ -46,6 +46,7 @@ smtpd_sasl_type = dovecot
 smtpd_sasl_path = private/auth
 broken_sasl_auth_clients = yes
 smtpd_sasl_security_options = noanonymous
+smtpd_tls_auth_only = yes
 
 # The internet hostname of this mail system.
 # The default is to use the fully-qualified domain name (FQDN) from gethostname(),

--- a/install/playbooks/roles/postfix/templates/main.cf
+++ b/install/playbooks/roles/postfix/templates/main.cf
@@ -49,7 +49,7 @@ smtpd_sasl_security_options = noanonymous
 
 # The internet hostname of this mail system.
 # The default is to use the fully-qualified domain name (FQDN) from gethostname(),
-myhostname = {{ network.hostname }}
+myhostname = smtp.{{ network.domain }}
 
 # Use virtual aliases, mailboxes, domains and transport
 virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf

--- a/install/playbooks/roles/postfix/templates/master.cf
+++ b/install/playbooks/roles/postfix/templates/master.cf
@@ -19,6 +19,7 @@ subcleanup unix  n       -       -       -       0       cleanup
 submission inet n       -       y       -       -       smtpd
   -o syslog_name=postfix/submission
   -o cleanup_service_name=subcleanup
+  -o smtpd_discard_ehlo_keywords=silent-discard,etrn
 #  -o smtpd_tls_security_level=encrypt
 #  -o smtpd_sasl_auth_enable=yes
 #  -o smtpd_reject_unlisted_recipient=no
@@ -30,6 +31,7 @@ submission inet n       -       y       -       -       smtpd
 #  -o milter_macro_daemon_name=ORIGINATING
 smtps     inet  n       -       y       -       -       smtpd
   -o syslog_name=postfix/smtps
+  -o smtpd_discard_ehlo_keywords=silent-discard,etrn
 #  -o smtpd_tls_wrappermode=yes
 #  -o smtpd_sasl_auth_enable=yes
 #  -o smtpd_reject_unlisted_recipient=no

--- a/install/playbooks/roles/postfix/templates/master.cf
+++ b/install/playbooks/roles/postfix/templates/master.cf
@@ -32,7 +32,7 @@ submission inet n       -       y       -       -       smtpd
 smtps     inet  n       -       y       -       -       smtpd
   -o syslog_name=postfix/smtps
   -o smtpd_discard_ehlo_keywords=silent-discard,etrn
-#  -o smtpd_tls_wrappermode=yes
+  -o smtpd_tls_wrappermode=yes
 #  -o smtpd_sasl_auth_enable=yes
 #  -o smtpd_reject_unlisted_recipient=no
 #  -o smtpd_client_restrictions=$mua_client_restrictions

--- a/install/playbooks/roles/sogo/templates/sogo.conf
+++ b/install/playbooks/roles/sogo/templates/sogo.conf
@@ -19,7 +19,9 @@
 
   // Mail parameters
   SOGoMailingMechanism = smtp;
-  SOGoSMTPAuthenticationType = plain;
+  // No authentication, as the server only supports it after STARTTLS
+  // and SOGo does not seem to support STARTTLS for SMTP
+  // SOGoSMTPAuthenticationType = plain;
   SOGoSMTPServer = "smtp.{{ network.domain }}:587";
   SOGoTrashFolderName = Trash;
   SOGoDraftsFolderName = Drafts;

--- a/tests/playbooks/roles/clamav/tasks/main.yml
+++ b/tests/playbooks/roles/clamav/tasks/main.yml
@@ -47,6 +47,7 @@
     --attach /tmp/clam.exe
     --attach-name '{{ test_filename }}.exe'
     --attach-type application/exe
+    -tls --tls-verify
     --auth
     --auth-user="{{ user0_uid }}"
     --auth-password="{{ user0_password }}"

--- a/tests/playbooks/roles/dev-support/defaults/main.yml
+++ b/tests/playbooks/roles/dev-support/defaults/main.yml
@@ -21,6 +21,7 @@ devel:
     - net-tools
     - file
     - swaks
+    - libnet-ssleay-perl
     - curl
     - locate
     - colorized-logs

--- a/tests/playbooks/roles/dovecot-fts/tasks/send-attachment.yml
+++ b/tests/playbooks/roles/dovecot-fts/tasks/send-attachment.yml
@@ -26,6 +26,7 @@
     --attach-type '{{ attachment.mime }}'
     --attach-name 'file.{{ attachment.extension }}'
     --attach '/tmp/file.{{ attachment.extension }}'
+    -tls --tls-verify
     --auth
     --auth-user="{{ users0_uid }}"
     --auth-password="{{ user0_password }}"

--- a/tests/playbooks/roles/postfix/tasks/check-extension-email.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-extension-email.yml
@@ -21,6 +21,7 @@
     --from="{{ users[0].mail }}"
     --to "{{ users[1].mail | regex_replace('@', '+lists@') }}"
     --h-Subject '{{ test_subject }}'
+    -tls --tls-verify
     --auth
     --auth-user="{{ user0_uid }}"
     --auth-password="{{ user0_password }}"

--- a/tests/playbooks/roles/postfix/tasks/check-simple-email.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-simple-email.yml
@@ -21,6 +21,7 @@
     --from="{{ users[0].mail }}"
     --to "{{ users[1].mail }}"
     --h-Subject '{{ test_subject }}'
+    -tls --tls-verify
     --auth
     --auth-user="{{ user0_uid }}"
     --auth-password="{{ user0_password }}"

--- a/tests/playbooks/roles/postfix/tasks/check-utf8-email.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-utf8-email.yml
@@ -21,6 +21,7 @@
     --from="{{ users[0].mail }}"
     --to "{{ users[1].aliases[0] }}"
     --h-Subject '{{ test_subject }}'
+    -tls --tls-verify
     --auth
     --auth-user="{{ user0_uid }}"
     --auth-password="{{ user0_password }}"


### PR DESCRIPTION
Some changes in the Postfix configuration concerning myhostname, the (unused) debian specific `/etc/mailname`, the `ETRN` command, TLS and authentication.

This does not changes the `*_restrictions` parameters. Maybe the submission ports configuration could later be made more restrictive? (Like `smtpd_tls_security_level=encrypt` if the SOGo configuration can be dealt with, and restrict submission to `sasl_authenticated` only?)
