### PR TITLE
POP3 optional features checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ official documentation.
 - Automatic copy of sent emails into the sent folder.
 - Automatic creation of the postmaster account and special email addresses using
   [RFC 2142](https://tools.ietf.org/html/rfc2142) specifications.
-- Dovecot configuration, IMAPS, POP3S, Quotas, ManageSieve, simple spam and ham learning
+- Dovecot configuration, IMAPS, optional POP3S, Quotas, ManageSieve, simple spam and ham learning
   by moving emails in and out the Junk folder, sieve and vacation scripts.
 - Virtual folders for server search: unread messages, conversations view, all messages, flagged
   and messages labelled as "important".

--- a/tests/playbooks/dns-records-email-pop3.yml
+++ b/tests/playbooks/dns-records-email-pop3.yml
@@ -1,0 +1,22 @@
+---
+
+# Test the DNS server for mail records (pop3 only)
+- hosts: homebox
+  vars:
+    records:
+      type: '{{ external_ip_type }}'
+      list:
+        - 'pop3.{{ network.domain }}'
+  roles:
+    - dns-records
+
+# Test the DNS server for service records (pop3 only)
+- hosts: homebox
+  vars:
+    records:
+      type: SRV
+      list:
+        - '_pop3._tcp.{{ network.domain }}'
+        - '_pop3s._tcp.{{ network.domain }}'
+  roles:
+    - dns-records

--- a/tests/playbooks/dns-records-email.yml
+++ b/tests/playbooks/dns-records-email.yml
@@ -25,7 +25,6 @@
       list:
         - 'imap.{{ network.domain }}'
         - 'smtp.{{ network.domain }}'
-        - 'pop3.{{ network.domain }}'
   roles:
     - dns-records
 
@@ -37,8 +36,6 @@
       list:
         - '_imap._tcp.{{ network.domain }}'
         - '_imaps._tcp.{{ network.domain }}'
-        - '_pop3._tcp.{{ network.domain }}'
-        - '_pop3s._tcp.{{ network.domain }}'
         - '_submission._tcp.{{ network.domain }}'
   roles:
     - dns-records

--- a/tests/playbooks/main.yml
+++ b/tests/playbooks/main.yml
@@ -49,6 +49,10 @@
 - import_playbook: dns-records-email.yml
   when: bind.install
 
+# Test DNS records for emails (POP3)
+- import_playbook: dns-records-email-pop3.yml
+  when: bind.install and mail.pop3
+
 # Test Jabber client to client functions
 - import_playbook: dns-records-jabber-c2s.yml
   when: bind.install and ejabberd.install


### PR DESCRIPTION
- Do not run POP3 specific DNS records tests if POP3 is disabled
- Updated the main readme to specify POP3 is optional