### PR TITLE
Let backup_ip checks be coherent

### DIFF
--- a/common/roles/external-ip-type/tasks/main.yml
+++ b/common/roles/external-ip-type/tasks/main.yml
@@ -31,7 +31,7 @@
 
 # Detect the backup IP address type (IPv4 or IPv6)
 - name: Set backup IP address type (A or AAAA)
-  when: network.backup_ip != None
+  when: backup_ip is defined and backup_ip != ""
   tags: facts
   register: backup_ip_type
   shell:
@@ -41,7 +41,7 @@
 
 - name: Set backup IP address type (A or AAAA)
   tags: facts
-  when: network.backup_ip != None
+  when: backup_ip is defined and backup_ip != ""
   set_fact:
     backup_ip_type: '{{ backup_ip_type.stdout }}'
 

--- a/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Copy DNS entries in bind cache directory (backup IP)
   notify: Restart bind
-  when: backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   copy:
     src: '/etc/bind/{{ file }}'
     dest: '/var/cache/bind/{{ file }}'

--- a/install/playbooks/roles/dns-server-bind/tasks/build-ip-info.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/build-ip-info.yml
@@ -27,29 +27,29 @@
 
 # Backup IP address
 - name: Build reverse IP address using shell
-  when: network.backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   shell: >-
-    dig -x {{ network.backup_ip }}
+    dig -x {{ backup_ip }}
     @{{ bind.forward[0] }}
     | awk 'f{print;f=0} /^;; QUESTION SECTION:/{f=1}'
     | sed -E 's/(^;|.IN.*)//g'
   register: reverse_backup_ip
 
 - name: Build the reverse IP address (works for IPv4 or IPv6)
-  when: network.backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   tags: facts
   set_fact:
     reverse_backup_ip: "{{ reverse_backup_ip.stdout }}"
 
 - name: Set external IP address type (A or AAAA)
-  when: network.backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   register: backup_ip_type
   shell:
-    echo {{ network.backup_ip }}
+    echo {{ backup_ip }}
     | grep -E '^[0-9\.]+$' 2>&1 >/dev/null
     && echo A || echo AAAA
 
 - name: Set external IP address type (A or AAAA)
-  when: network.backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   set_fact:
     backup_ip_type: '{{ (backup_ip_type.stdout) }}'

--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -66,7 +66,7 @@
     loop_var: file
 
 - name: Copy the configuration template
-  when: backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   tags: config
   vars:
     serial: "{{ lookup('pipe', 'date +%s') }}"
@@ -237,7 +237,7 @@
     loop_var: file
 
 - name: Copy DNS entries in bind cache directory (backup IP)
-  when: backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   copy:
     src: '/etc/bind/{{ file }}'
     dest: '/var/cache/bind/{{ file }}'
@@ -261,7 +261,7 @@
     line: '127.0.0.1    main.{{ network.domain }}'
 
 - name: Ensure the backup record resolves to me
-  when: backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   tags: hosts
   lineinfile:
     path: /etc/hosts

--- a/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
@@ -12,7 +12,7 @@
 # This is checking that the DNS server has been fully propagated
 - name: Check DNS propagation for backup IP address
   register: backup_ip_check
-  when: network.backup_ip is defined
+  when: backup_ip is defined and backup_ip != ""
   shell: >-
     host backup.{{ network.domain }}
   retries: '{{ bind.propagation.retries | default(10) }}'

--- a/install/playbooks/roles/dovecot/templates/40-dovecot.bind
+++ b/install/playbooks/roles/dovecot/templates/40-dovecot.bind
@@ -1,12 +1,12 @@
 ;; SMTP server IP address, MX should point to a proper A record
 imap    IN       {{ "%-4s" | format(external_ip_type) }}      {{ external_ip }}
-{% if backup_ip is defined %}
+{% if backup_ip is defined and backup_ip != "" %}
 imap    IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 {% endif %}
 
 {% if mail.pop3 %}
 pop3    IN       {{ "%-4s" | format(external_ip_type) }}      {{ external_ip }}
-{% if backup_ip is defined %}
+{% if backup_ip is defined and backup_ip != "" %}
 pop3    IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 {% endif %}
 {% endif %}

--- a/install/playbooks/roles/ejabberd/templates/50-jabber.bind
+++ b/install/playbooks/roles/ejabberd/templates/50-jabber.bind
@@ -1,6 +1,6 @@
 ;; XMPP Server IP address, should be an A/AAAA record
 xmpp    IN       {{ "%-4s" | format(external_ip_type) }}      {{ external_ip }}
-{% if backup_ip is defined %}
+{% if backup_ip is defined and backup_ip != "" %}
 xmpp    IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 {% endif %}
 

--- a/install/playbooks/roles/mta-sts/templates/mta-sts.txt
+++ b/install/playbooks/roles/mta-sts/templates/mta-sts.txt
@@ -1,7 +1,7 @@
 version: STSv1
 mode:  {{ system.devel | ternary("testing", mail.mta_sts.mode) }}
 mx: smtp.{{ network.domain }}
-{% if network.backup_ip is defined and network.backup_ip != "" %}
+{% if backup_ip is defined and backup_ip != "" %}
 mx: smtp2.{{ network.domain }}
 {% endif %}
 {% for mxb in bind.mx_backup %}


### PR DESCRIPTION
Use 'backup_ip is defined and backup_ip != ""' everywhere. It is already
used in the dns-server-bind playbook.

The external-ip-type common playbook sets the backup_ip fact to the
empty string if `network.auto_detect_ip` is false and
`network.backup_ip` is null, or if `network.auto_detect_ip` is true and
the obtained `backup_ip` is different from the external_ip.

The checks cannot reliably be made on `network.backup_ip`.

Use `backup_ip` instead of `network.backup_ip` where relevant.