### PR TITLE
Fix the removal of the postmaster account

### DIFF
--- a/install/playbooks/roles/ldap/tasks/main.yml
+++ b/install/playbooks/roles/ldap/tasks/main.yml
@@ -441,7 +441,7 @@
   ldap_entry:
     bind_dn: '{{ ldap.admin.dn }}'
     bind_pw: '{{ lookup("password", ldap.adminPasswdParams) }}'
-    dn: 'cn=manager account,{{ ldap.users.dn }}'
+    dn: 'cn=postmaster account,{{ ldap.users.dn }}'
     state: absent
 
 - name: Create the default postmaster aliases


### PR DESCRIPTION
This must not be used very often. During the ldap setup, the task is only called when the `clean` variable is set to remove the postmaster account before creating it again.