### PR TITLE
Dns reverse zones

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -484,6 +484,12 @@ bind_default:
     algo: RSASHA256
   # Aditional records to be generated
   extra_records: []
+  # Generate reverse zones for the server's IP addresses.
+  # This is needed only if the reverse zones corresponding to these IP
+  # addresses were delegated to you by your ISP or hosting provider.
+  # You are most likely not in that situation and might need to configure the
+  # reverse DNS records at the level of your ISP or hosting provider.
+  generate_reverse: false
 
 ###############################################################################
 # Gogs installation with LDAP authentication.

--- a/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
@@ -12,27 +12,28 @@
 - name: Copy DNS entries in bind cache directory (main IP)
   notify: Restart bind
   copy:
-    src: '/etc/bind/{{ file }}'
-    dest: '/var/cache/bind/{{ file }}'
+    src: '/etc/bind/forward.{{ network.domain }}'
+    dest: '/var/cache/bind/forward.{{ network.domain }}'
     owner: bind
     group: bind
     remote_src: true
-  with_items:
-    - 'forward.{{ network.domain }}'
-    - 'reverse-main.{{ network.domain }}'
-  loop_control:
-    loop_var: file
 
-- name: Copy DNS entries in bind cache directory (backup IP)
+- name: Copy DNS entries in bind cache directory (reverse for main IP)
+  when: bind.generate_reverse
   notify: Restart bind
-  when: backup_ip is defined and backup_ip != ""
   copy:
-    src: '/etc/bind/{{ file }}'
-    dest: '/var/cache/bind/{{ file }}'
+    src: '/etc/bind/reverse-main.{{ network.domain }}'
+    dest: '/var/cache/bind/reverse-main.{{ network.domain }}'
     owner: bind
     group: bind
     remote_src: true
-  with_items:
-    - 'reverse-backup.{{ network.domain }}'
-  loop_control:
-    loop_var: file
+
+- name: Copy DNS entries in bind cache directory (reverse for backup IP)
+  notify: Restart bind
+  when: bind.generate_reverse and backup_ip is defined and backup_ip != ""
+  copy:
+    src: '/etc/bind/reverse-backup.{{ network.domain }}'
+    dest: '/var/cache/bind/reverse-backup.{{ network.domain }}'
+    owner: bind
+    group: bind
+    remote_src: true

--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -39,11 +39,10 @@
   tags: config
   vars:
     serial: "{{ lookup('pipe', 'date +%s') }}"
-    record_name: main
+    record_name: "{{ 'smtp' if postfix.install else 'main' }}"
     reverse_ip_address: '{{ reverse_ip }}'
     external_ip_address: '{{ external_ip }}'
     ip_type: '{{ external_ip_type }}'
-    ptr_id: 10
   template:
     src: '{{ file.src }}'
     dest: '{{ file.dest }}'
@@ -70,11 +69,10 @@
   tags: config
   vars:
     serial: "{{ lookup('pipe', 'date +%s') }}"
-    record_name: backup
+    record_name: "{{ 'smtp2' if postfix.install else 'backup' }}"
     reverse_ip_address: '{{ reverse_backup_ip }}'
     external_ip_address: '{{ backup_ip }}'
     ip_type: '{{ backup_ip_type }}'
-    ptr_id: 20
   template:
     src: '{{ file.src }}'
     dest: '{{ file.dest }}'

--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -35,11 +35,10 @@
 - name: Build main and reverse IP address information
   include_tasks: build-ip-info.yml
 
-- name: Copy the configuration template
+- name: Copy the forward configuration template
   tags: config
   vars:
     serial: "{{ lookup('pipe', 'date +%s') }}"
-    record_name: "{{ 'smtp' if postfix.install else 'main' }}"
     reverse_ip_address: '{{ reverse_ip }}'
     external_ip_address: '{{ external_ip }}'
     ip_type: '{{ external_ip_type }}'
@@ -56,16 +55,27 @@
     - src: named.conf.local
       dest: '/etc/bind/named.conf.local'
       mode: '0640'
-    - src: reverse-domain
-      dest: '/etc/bind/reverse-main.{{ network.domain }}'
-      mode: '0640'
     - src: forward-tail
       dest: '/etc/homebox/dns-entries.d/99-tail.bind'
   loop_control:
     loop_var: file
 
-- name: Copy the configuration template
-  when: backup_ip is defined and backup_ip != ""
+- name: Copy the main reverse configuration template
+  when: bind.generate_reverse
+  tags: config
+  vars:
+    serial: "{{ lookup('pipe', 'date +%s') }}"
+    record_name: "{{ 'smtp' if postfix.install else 'main' }}"
+    reverse_ip_address: '{{ reverse_ip }}'
+    external_ip_address: '{{ external_ip }}'
+    ip_type: '{{ external_ip_type }}'
+  template:
+    src: reverse-domain
+    dest: '/etc/bind/reverse-main.{{ network.domain }}'
+    mode: '0640'
+
+- name: Copy the backup reverse configuration template
+  when: bind.generate_reverse and backup_ip is defined and backup_ip != ""
   tags: config
   vars:
     serial: "{{ lookup('pipe', 'date +%s') }}"
@@ -74,13 +84,9 @@
     external_ip_address: '{{ backup_ip }}'
     ip_type: '{{ backup_ip_type }}'
   template:
-    src: '{{ file.src }}'
-    dest: '{{ file.dest }}'
-  with_items:
-    - src: reverse-domain
-      dest: '/etc/bind/reverse-backup.{{ network.domain }}'
-  loop_control:
-    loop_var: file
+    src: reverse-domain
+    dest: '/etc/bind/reverse-backup.{{ network.domain }}'
+    mode: '0640'
 
 - name: Build the final bind configuration
   tags: config
@@ -223,29 +229,29 @@
 
 - name: Copy DNS entries in bind cache directory (main IP)
   copy:
-    src: '/etc/bind/{{ file }}'
-    dest: '/var/cache/bind/{{ file }}'
+    src: '/etc/bind/forward.{{ network.domain }}'
+    dest: '/var/cache/bind/forward.{{ network.domain }}'
     owner: bind
     group: bind
     remote_src: true
-  with_items:
-    - 'forward.{{ network.domain }}'
-    - 'reverse-main.{{ network.domain }}'
-  loop_control:
-    loop_var: file
 
-- name: Copy DNS entries in bind cache directory (backup IP)
-  when: backup_ip is defined and backup_ip != ""
+- name: Copy DNS entries in bind cache directory (reverse for main IP)
+  when: bind.generate_reverse
   copy:
-    src: '/etc/bind/{{ file }}'
-    dest: '/var/cache/bind/{{ file }}'
+    src: '/etc/bind/reverse-main.{{ network.domain }}'
+    dest: '/var/cache/bind/reverse-main.{{ network.domain }}'
     owner: bind
     group: bind
     remote_src: true
-  with_items:
-    - 'reverse-backup.{{ network.domain }}'
-  loop_control:
-    loop_var: file
+
+- name: Copy DNS entries in bind cache directory (reverse for backup IP)
+  when: bind.generate_reverse and backup_ip is defined and backup_ip != ""
+  copy:
+    src: '/etc/bind/reverse-backup.{{ network.domain }}'
+    dest: '/var/cache/bind/reverse-backup.{{ network.domain }}'
+    owner: bind
+    group: bind
+    remote_src: true
 
 - name: Restart bind
   service:

--- a/install/playbooks/roles/dns-server-bind/templates/named.conf.local
+++ b/install/playbooks/roles/dns-server-bind/templates/named.conf.local
@@ -9,6 +9,7 @@ zone    "{{ network.domain }}" IN {
 {% endif %}
         };
 
+{% if bind.generate_reverse %}
 # Main IP reverse DNS entries
 zone    "{{ reverse_ip }}" {
         type master;
@@ -21,4 +22,5 @@ zone    "{{ reverse_backup_ip }}" {
         type master;
         file "reverse-backup.{{ network.domain }}";
         };
+{% endif %}
 {% endif %}

--- a/install/playbooks/roles/dns-server-bind/templates/reverse-domain
+++ b/install/playbooks/roles/dns-server-bind/templates/reverse-domain
@@ -1,17 +1,16 @@
 $TTL    {{ bind.ttl }}
 
-{{ reverse_ip_address }} IN      SOA     {{ network.domain }}. hostmaster.{{ network.domain }}. (
+{{ reverse_ip_address }} IN      SOA     main.{{ network.domain }}. hostmaster.{{ network.domain }}. (
                         {{ (serial | int) + 1 }}
                         {{ bind.refresh }}
                         {{ bind.retry }}
                         {{ bind.expire }}
                         {{ bind.neg_cache_ttl }} )
-; Main IP address
-{{ reverse_ip_address }}       IN      NS      {{ record_name }}.{{ network.domain }}.
-
 ;Name Server Information
-@       IN      NS      {{ record_name }}.{{ network.domain }}.
-{{ "%-6s" | format(record_name) }}  IN      {{ "%-4s" | format(ip_type) }}    {{ external_ip_address }}
+{{ reverse_ip_address }}       IN      NS      main.{{ network.domain }}.
+{% if backup_ip is defined and backup_ip != "" %}
+{{ reverse_ip_address }}       IN      NS      backup.{{ network.domain }}.
+{% endif %}
 
 ;Reverse lookup ({{ record_name }} IP address)
-{{ ptr_id }}      IN      PTR     {{ record_name }}.{{ network.domain }}.
+{{ reverse_ip_address }}      IN      PTR     {{ record_name }}.{{ network.domain }}.


### PR DESCRIPTION
These commits modify the reverse DNS zones generation and add an boolean option to generate or not the zones.

- Announce the nameserver in the SOA.
- Announce the backup nameserver if available.
- Use the full reverse IP address for the PTR record.
- Set the reverse records to `smtp` and `smtp2` if the server is used as a
  mail server with Postfix, or else use `main` and `backup`.
- Add and use the `bind.generate_reverse` option as a boolean.
- Do not generate the reverse zones by default.

The idea is that the reverse zones are needed if the reverse management is delegated from the ISP or host (or LIR), but I don't think that's the most common case.

If it is to be generated and the server is used as a mail server, I guess the best practice would be to use the MX hostname as reverse DNS record.

What do you think ?