### PR TITLE
Simplify home directories creation

### DIFF
--- a/install/playbooks/roles/ldap/variables/main.yml
+++ b/install/playbooks/roles/ldap/variables/main.yml
@@ -4,6 +4,4 @@
 users_defaults:
   uid_start: 1001
   gid_start: 1001
-  shell: /bin/dash
-  group: users
-  groups: mail
+  shell: /bin/bash

--- a/install/playbooks/roles/user-setup/tasks/main.yml
+++ b/install/playbooks/roles/user-setup/tasks/main.yml
@@ -18,67 +18,7 @@
     group: users
     state: directory
 
-- name: Create the user account maildir folders
-  tags: accounts
-  file:
-    path: '/home/users/{{ user.uid }}/mails/maildir'
-    owner: '{{ user.uid }}'
-    group: users
-    state: directory
-    mode: 0700
-    recurse: false
-  with_items:
-    - '{{ users }}'
-    - uid: postmaster
-  loop_control:
-    loop_var: user
-
-- name: Create the user account mail folders
-  tags: accounts
-  file:
-    path: '/home/users/{{ user.uid }}/mails/sieve/logs'
-    owner: '{{ user.uid }}'
-    group: users
-    state: directory
-    mode: 0700
-    recurse: true
-  with_items:
-    - '{{ users }}'
-    - uid: postmaster
-  loop_control:
-    loop_var: user
-
-- name: Create the user account mail indexes folders
-  tags: accounts
-  file:
-    path: '/home/users/{{ user.uid }}/mails/indexes'
-    owner: '{{ user.uid }}'
-    group: users
-    state: directory
-    mode: 0700
-    recurse: true
-  with_items:
-    - '{{ users }}'
-    - uid: postmaster
-  loop_control:
-    loop_var: user
-
-- name: Create the user account mail import folders
-  tags: accounts
-  file:
-    path: '/home/users/{{ user.uid }}/mails/import'
-    owner: '{{ user.uid }}'
-    group: users
-    state: directory
-    mode: 0700
-    recurse: true
-  with_items:
-    - '{{ users }}'
-    - uid: postmaster
-  loop_control:
-    loop_var: user
-
-- name: Also add these folders into the skeleton, for new users
+- name: Add homebox mail and config folders to the skeleton
   tags: accounts
   file:
     path: '{{ dir }}'
@@ -97,16 +37,12 @@
   loop_control:
     loop_var: dir
 
-- name: Create the custom configuration directory for each user
-  file:
-    path: '/home/users/{{ user.uid }}/.config/homebox'
-    owner: '{{ user.uid }}'
-    group: users
-    state: directory
-    recurse: true
+- name: Create the users home folders from /etc/skel
+  tags: accounts
+  command: 'mkhomedir_helper {{ user.uid }} 077 /etc/skel'
   with_items:
     - '{{ users }}'
-    - uid: postmaster
+    - '{{ ldap.postmaster }}'
   loop_control:
     loop_var: user
 
@@ -141,3 +77,10 @@
     - '{{ administrators | list }}'
   loop_control:
     loop_var: user
+
+- name: Set the home folders to the group users
+  tags: accounts
+  file:
+    path: '/home/users/'
+    group: users
+    recurse: yes

--- a/install/playbooks/user-setup.yml
+++ b/install/playbooks/user-setup.yml
@@ -4,5 +4,6 @@
 - hosts: homebox
   vars_files:
     - '{{ playbook_dir }}/../../config/system.yml'
+    - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
     - user-setup

--- a/tests/playbooks/roles/ldap/tasks/main.yml
+++ b/tests/playbooks/roles/ldap/tasks/main.yml
@@ -73,7 +73,7 @@
 - name: Check that every user is in the system, with the correct attributes
   tags: ldap
   vars:
-    shell: /bin/dash
+    shell: /bin/bash
     homeBase: /home/users
   shell: >-
     getent passwd |


### PR DESCRIPTION
Modify the tasks in the `user_setup.yml`.

- First, add files to /etc/skel.
- Then, use PAM's mkhomedir_helper to create home directories. It uses the
  primary user group for the files creation, so force the home directories
  to be set to the group "users".
- Doing so, copy bash related and .profile files to home directories.

Give users a bash shell by default.