### PR TITLE
Fix TLS-RPT DNS record test

### DIFF
--- a/tests/playbooks/dns-records-email.yml
+++ b/tests/playbooks/dns-records-email.yml
@@ -79,6 +79,6 @@
         - name: '_mta-sts.{{ network.domain }}'
           value: 'v=STSv1; id=[a-zA-Z]+'
         - name: '_smtp._tls.{{ network.domain }}'
-          value: 'main.{{ network.domain }}'
+          value: 'v=TLSRPTv1; rua=mailto:security@{{ network.domain }};'
   roles:
     - dns-records


### PR DESCRIPTION
We missed that one.

Check for "v=TLSRPTv1;[...]" content.