### PR TITLE
Mail configuration

### DIFF
--- a/install/playbooks/roles/postfix/templates/master.cf
+++ b/install/playbooks/roles/postfix/templates/master.cf
@@ -20,27 +20,13 @@ submission inet n       -       y       -       -       smtpd
   -o syslog_name=postfix/submission
   -o cleanup_service_name=subcleanup
   -o smtpd_discard_ehlo_keywords=silent-discard,etrn
-#  -o smtpd_tls_security_level=encrypt
-#  -o smtpd_sasl_auth_enable=yes
-#  -o smtpd_reject_unlisted_recipient=no
-#  -o smtpd_client_restrictions=$mua_client_restrictions
-#  -o smtpd_helo_restrictions=$mua_helo_restrictions
-#  -o smtpd_sender_restrictions=$mua_sender_restrictions
-#  -o smtpd_recipient_restrictions=
-#  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
-#  -o milter_macro_daemon_name=ORIGINATING
+  -o smtpd_relay_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
 smtps     inet  n       -       y       -       -       smtpd
   -o syslog_name=postfix/smtps
+  -o cleanup_service_name=subcleanup
   -o smtpd_discard_ehlo_keywords=silent-discard,etrn
   -o smtpd_tls_wrappermode=yes
-#  -o smtpd_sasl_auth_enable=yes
-#  -o smtpd_reject_unlisted_recipient=no
-#  -o smtpd_client_restrictions=$mua_client_restrictions
-#  -o smtpd_helo_restrictions=$mua_helo_restrictions
-#  -o smtpd_sender_restrictions=$mua_sender_restrictions
-#  -o smtpd_recipient_restrictions=
-#  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
-#  -o milter_macro_daemon_name=ORIGINATING
+  -o smtpd_relay_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
 #628       inet  n       -       y       -       -       qmqpd
 pickup    unix  n       -       y       60      1       pickup
 cleanup   unix  n       -       y       -       0       cleanup

--- a/install/playbooks/roles/sogo/templates/sogo.conf
+++ b/install/playbooks/roles/sogo/templates/sogo.conf
@@ -22,7 +22,7 @@
   // No authentication, as the server only supports it after STARTTLS
   // and SOGo does not seem to support STARTTLS for SMTP
   // SOGoSMTPAuthenticationType = plain;
-  SOGoSMTPServer = "smtp.{{ network.domain }}:587";
+  SOGoSMTPServer = "smtp.{{ network.domain }}:{{ mail.postfix.submission.port }}";
   SOGoTrashFolderName = Trash;
   SOGoDraftsFolderName = Drafts;
   SOGoIMAPServer = "imap://imap.{{ network.domain }}:1143/?tls=YES";


### PR DESCRIPTION
A commit to configure `smtpd_relay_restrictions` for submission ports in `master.cf` with only `mynetworks` and `sasl_authenticated`.

Another commit to use the `mail.postfix.submission.port` variable instead of the value `587` directly in `sogo.conf`.