### PR TITLE
Use only TLS ports with Dovecot

### DIFF
--- a/install/playbooks/roles/autoconfig/templates/config-v1.1.xml
+++ b/install/playbooks/roles/autoconfig/templates/config-v1.1.xml
@@ -14,13 +14,6 @@
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <incomingServer type="imap">
-      <hostname>imap.{{ network.domain }}</hostname>
-      <port>143</port>
-      <socketType>STARTTLS</socketType>
-      <username>%EMAILLOCALPART%</username>
-      <authentication>password-cleartext</authentication>
-    </incomingServer>
 
 {% if mail.pop3 %}
     <!-- POP3 -->
@@ -28,13 +21,6 @@
       <hostname>pop3.{{ network.domain }}</hostname>
       <port>995</port>
       <socketType>SSL</socketType>
-      <username>%EMAILLOCALPART%</username>
-      <authentication>password-cleartext</authentication>
-    </incomingServer>
-    <incomingServer type="pop3">
-      <hostname>pop3.{{ network.domain }}</hostname>
-      <port>110</port>
-      <socketType>STARTTLS</socketType>
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>

--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -172,8 +172,6 @@
     port: '{{ rule.port }}'
     comment: '{{ rule.comment }}'
   with_items:
-    - comment: Allow IMAP access
-      port: 143
     - comment: Allow IMAPS access
       port: 993
     - comment: Allow Managesieve access
@@ -188,15 +186,8 @@
     rule: allow
     proto: tcp
     src: any
-    port: '{{ rule.port }}'
-    comment: '{{ rule.comment }}'
-  with_items:
-    - comment: Allow POP3 access
-      port: 110
-    - comment: Allow POP3S access
-      port: 995
-  loop_control:
-    loop_var: rule
+    port: 995
+    comment: Allow POP3S access
 
 - name: Create the post-login script directory
   file:

--- a/install/playbooks/roles/dovecot/templates/40-dovecot.bind
+++ b/install/playbooks/roles/dovecot/templates/40-dovecot.bind
@@ -13,14 +13,13 @@ pop3    IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 
 
 ;; RFC 6186 entries, should point to an "A" record
-_imap._tcp 3600 IN SRV 10 0 143 imap.{{ network.domain }}.
+;; See section 3.4 for examples of priorities and unavailable ports:
+;; https://tools.ietf.org/html/rfc6186#section-3.4
+_imap._tcp 3600 IN SRV 0 0 0 .
 _imaps._tcp 3600 IN SRV 10 0 993 imap.{{ network.domain }}.
+_pop3._tcp 3600 IN SRV 0 0 0 .
 {% if mail.pop3 %}
-_pop3._tcp 3600 IN SRV 20 0 110 pop3.{{ network.domain }}.
 _pop3s._tcp 3600 IN SRV 20 0 995 pop3.{{ network.domain }}.
 {% else %}
-;; POP3 and POP3S are not available
-;; https://tools.ietf.org/html/rfc6186#section-3.4
-_pop3._tcp 3600 IN SRV 0 0 0 .
 _pop3s._tcp 3600 IN SRV 0 0 0 .
 {% endif %}

--- a/install/playbooks/roles/dovecot/templates/conf.d/10-master.conf
+++ b/install/playbooks/roles/dovecot/templates/conf.d/10-master.conf
@@ -40,11 +40,7 @@ service imap-login {
 
 service pop3-login {
   inet_listener pop3 {
-{% if mail.pop3 %}
-    port = 110
-{% else %}
     port = 0
-{% endif %}
   }
   inet_listener pop3s {
 {% if mail.pop3 %}

--- a/tests/playbooks/dns-records-email-pop3.yml
+++ b/tests/playbooks/dns-records-email-pop3.yml
@@ -23,7 +23,7 @@
       type: SRV
       list:
         - name: '_pop3._tcp.{{ network.domain }}'
-          value: 'pop3\.{{ network.domain }}'
+          value: '0 0 0 \.'
         - name: '_pop3s._tcp.{{ network.domain }}'
           value: 'pop3\.{{ network.domain }}'
   roles:

--- a/tests/playbooks/dns-records-email.yml
+++ b/tests/playbooks/dns-records-email.yml
@@ -38,7 +38,7 @@
       type: SRV
       list:
         - name: '_imap._tcp.{{ network.domain }}'
-          value: 'imap\.{{ network.domain }}'
+          value: '0 0 0 \.'
         - name: '_imaps._tcp.{{ network.domain }}'
           value: 'imap\.{{ network.domain }}'
         - name: '_submission._tcp.{{ network.domain }}'


### PR DESCRIPTION
This change does the necessary to keep only the TLS ports open with Dovecot (imaps, pop3s), and closes the ports using STARTTLS (imap, pop3).

Using this will consider that all email clients used with the server will be able to use TLS (without STARTTLS). Some providers appear to do this by default, too (eg Gmail, Fastmail). Fastmail has a good write-up on this: https://www.fastmail.com/help/technical/ssltlsstarttls.html.

The auto{config,discover} configurations already announce the imaps port only (and pop3s if enabled).

What is your opinion on such a change?


Keep the `imap` listener on port `143` for the needs of the webmails
through `imapproxy` on localhost.

Disable the `pop3` listener on port 110, even if `mail.pop3` is enabled.

Close the firewall ports for `imap` and `pop3`.

Announce only `imaps`, and `pop3s` if POP3 is enabled:

- with the DNS SRV records;

- in `autoconfig` and `autodiscover`.

Update the tests for the DNS SRV records.