### PR TITLE
Fix ejabberd ldap_uids config option

### DIFF
--- a/install/playbooks/roles/ejabberd/templates/ejabberd.yml
+++ b/install/playbooks/roles/ejabberd/templates/ejabberd.yml
@@ -148,7 +148,8 @@ ldap_rootdn: "{{ ldap.readonly.dn }}"
 ldap_password: "{{ lookup('password', ldap.roPasswdParams) }}"
 ldap_base: "{{ ldap.organization.base }}"
 ldap_filter: "(objectClass=shadowAccount)"
-ldap_uids: '[{"mail","%u@{{ network.domain }}"}]'
+ldap_uids:
+  - "mail": "%u@{{ network.domain }}"
 
 ###.  ===============
 ###'  TRAFFIC SHAPERS


### PR DESCRIPTION
Use a yaml form `"mail": "%u@{{ network.domain}}"` instead of what seems
to be an erlang config format `"mail", "%u@{{ network.domain }}"`.

Use an expanded list to avoid confusion between a yaml list of objects
and the similar erlang format `[{...}]`.

The ldap auth information was somehow found, but this change avoids
error messages like:
```
ignoring option 'ldap_uids' with invalid value: '[{"mail","%u@[...]
```