### PR TITLE
make the acl for the certificate directories recursive

### DIFF
--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -40,8 +40,8 @@
     etype: user
     permissions: rx
     state: present
+    recursive: yes
   with_items:
-    - /etc/letsencrypt
     - /etc/letsencrypt/archive
     - /etc/letsencrypt/live
   loop_control:

--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -41,6 +41,7 @@
     permissions: rx
     state: present
     recursive: yes
+    default: yes
   with_items:
     - /etc/letsencrypt/archive
     - /etc/letsencrypt/live

--- a/install/playbooks/roles/ejabberd/tasks/main.yml
+++ b/install/playbooks/roles/ejabberd/tasks/main.yml
@@ -128,6 +128,7 @@
     etype: user
     permissions: rwx
     state: present
+    default: yes
 
 - name: Create the http upload jabber site
   tags: jabber

--- a/install/playbooks/roles/ldap/tasks/main.yml
+++ b/install/playbooks/roles/ldap/tasks/main.yml
@@ -107,6 +107,7 @@
     permissions: rx
     state: present
     recursive: yes
+    default: yes
   with_items:
       - /etc/letsencrypt/archive
       - /etc/letsencrypt/live

--- a/install/playbooks/roles/ldap/tasks/main.yml
+++ b/install/playbooks/roles/ldap/tasks/main.yml
@@ -106,8 +106,8 @@
     etype: user
     permissions: rx
     state: present
+    recursive: yes
   with_items:
-      - /etc/letsencrypt
       - /etc/letsencrypt/archive
       - /etc/letsencrypt/live
   loop_control:

--- a/install/playbooks/roles/nginx/tasks/main.yml
+++ b/install/playbooks/roles/nginx/tasks/main.yml
@@ -17,8 +17,8 @@
     etype: user
     permissions: rx
     state: present
+    recursive: yes
   with_items:
-    - /etc/letsencrypt
     - /etc/letsencrypt/archive
     - /etc/letsencrypt/live
   loop_control:

--- a/install/playbooks/roles/nginx/tasks/main.yml
+++ b/install/playbooks/roles/nginx/tasks/main.yml
@@ -18,6 +18,7 @@
     permissions: rx
     state: present
     recursive: yes
+    default: yes
   with_items:
     - /etc/letsencrypt/archive
     - /etc/letsencrypt/live

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -21,6 +21,7 @@
     permissions: rx
     state: present
     recursive: yes
+    default: yes
   with_items:
     - /etc/letsencrypt/archive
     - /etc/letsencrypt/live

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -20,8 +20,8 @@
     etype: user
     permissions: rx
     state: present
+    recursive: yes
   with_items:
-    - /etc/letsencrypt
     - /etc/letsencrypt/archive
     - /etc/letsencrypt/live
   loop_control:


### PR DESCRIPTION
The acl's for the certificate directories should also apply to the subdirectories. Apparently this is implicitly applied on Debian Stretch, but on Debian Buster it is not. 

I think it is caused by:

[Debian Changelog:](https://metadata.ftp-master.debian.org/changelogs//main/a/acl/acl_2.2.53-4_changelog)

    acl (2.2.53-1) unstable; urgency=medium
    [...]
    * Enable all hardening build flags.

I omitted acl for /etc/letsencrypt since access to the files in this directory does not seem to be necessary.

I tested the change on Debian Stretch and it does not seem to cause any problems.