### PR TITLE
Fixes for the ejabberd renewal hook

### DIFF
--- a/install/playbooks/roles/ejabberd/files/renewal-hook.sh
+++ b/install/playbooks/roles/ejabberd/files/renewal-hook.sh
@@ -12,14 +12,13 @@ for fqdn in $RENEWED_DOMAINS; do
     # Get the subdomain
     sub=$(expr "$fqdn" : '\([^.]*\)')
 
-    if [ "$sub" = "xmpp" ]; then
-        cd "/etc/letsencrypt/live/$DOMAIN"
+    if [ "$fqdn" = "$DOMAIN" ]; then
+        cd "$RENEWED_LINEAGE"
         /bin/cat privkey.pem fullchain.pem > /etc/ejabberd/default.pem
         do_restart=1
-    fi
 
-    if [ "$sub" = "conference" ]; then
-        cd "/etc/letsencrypt/live/$DOMAIN"
+    elif [ "$sub" = "conference" ]; then
+        cd "$RENEWED_LINEAGE"
         /bin/cat privkey.pem fullchain.pem > /etc/ejabberd/conference.pem
         do_restart=1
     fi
@@ -27,7 +26,5 @@ done
 
 if [ "$do_restart" = "1" ]; then
     echo "Reloading XMPP ejabberd server"
-    chown ejabberd:root /etc/ejabberd/*.pem
-    chmod 640 /etc/ejabberd/*.pem
     systemctl restart ejabberd
 fi


### PR DESCRIPTION
A follow up on #241.

Set the default ejabberd certificate from the main domain certificate
(`$DOMAIN` from `/etc/homebox/main.cf`). The `xmpp` subdomain is handled
by `nginx` and the `00-base.sh` renewal hook. The `conference` subdomain
handling is unchanged.

The renewal hooks are called once per certificate. a certficate can
contain several `$RENEWED_DOMAINS`. In homebox, the different domains
used by ejabberd are getting separate certificates, so the renewal hook
will be called for either one or the other, not both at the same time.

Use the `$RENEWED_LINEAGE` variable to get the live directory path for
the current certificate.

Do not change `/etc/ejabberd/*.pem` ownership and permissions from what
has been set by the ansible role tasks (`root:ejabberd`, `440`).