### PR TITLE
Let git ignore python3 cache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ backup/*
 # Allow to include modules excluded from the repository
 modules/*
 !modules/readme.md
+
+# Ignore python3 cache directories
+__pycache__/


### PR DESCRIPTION
Not sure why it was not generated before, but now with python 3.7.5 and ansible 2.8.3, I have a `__pycache__` directory is generated in `common/connection-plugins` for the `ssh_fwknop.py` script on any ansible-playbook call.
