### PR TITLE
Use IP addresses in the SPF record

### DIFF
--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -218,6 +218,24 @@
 
 # Create entries for the DNS server ===========================================
 
+# Use IP addresses as SPF mechanisms for the server itself
+- name: Add the external IP address as SPF sender
+  tags: spf
+  set_fact:
+    spf_senders: '{{ "ip6:" + external_ip if external_ip | ipv6 else "ip4:" + external_ip }}'
+
+- name: Add the backup IP address as SPF sender
+  when: backup_ip is defined and backup_ip != ""
+  tags: spf
+  set_fact:
+    spf_senders: '{{ spf_senders }} {{ "ip6:" + backup_ip if backup_ip | ipv6 else "ip4:" + backup_ip }}'
+
+- name: Add the user configured extra senders to the SPF record
+  when: mail.extra_senders
+  tags: spf
+  set_fact:
+    spf_senders: '{{ spf_senders }} {{ mail.extra_senders | join(" ") }}'
+
 # Use "soft fail" in development mode
 - name: Set the SPF qualifier as "soft fail"
   tags: spf

--- a/install/playbooks/roles/postfix/templates/30-postfix.bind
+++ b/install/playbooks/roles/postfix/templates/30-postfix.bind
@@ -16,13 +16,8 @@ _submission._tcp 3600 IN SRV 0 0 {{ mail.postfix.submission.port }} smtp.{{ netw
 _submission._tcp 3600 IN SRV 0 0 {{ mail.postfix.submission.port }} smtp2.{{ network.domain }}.
 {% endif %}
 
-{% if mail.extra_senders %}
-;; SPF record: include all MX records and the extra senders
-@       IN       TXT    "v=spf1 mx {{ mail.extra_senders | join(' ') }} {{ spf_qualifier }}all"
-{% else %}
-;; SPF record: include all MX records
-@       IN       TXT    "v=spf1 mx {{ spf_qualifier }}all"
-{% endif %}
+;; SPF record
+@       IN       TXT    "v=spf1 {{ spf_senders }} {{ spf_qualifier }}all"
 
 {% if bind.mx_backup != [] %}
 ;; Backup records if the server is unreachable


### PR DESCRIPTION
Use the `ip4` and `ip6` mechanisms to avoid DNS queries for servers
checking the SPF record.

This is done under the assumption that the IP addresses are static, and
will not be renumbered without an update of the SPF record.

https://tools.ietf.org/html/rfc7208#section-10.1.1
