### PR TITLE
Some fixes following 231 and 238 v2

### DIFF
--- a/common/roles/external-ip-type/tasks/main.yml
+++ b/common/roles/external-ip-type/tasks/main.yml
@@ -20,19 +20,19 @@
 
 # Backup IP address if defined
 - name: Get the backup IP address
-  when: network.backup_ip != None
+  when: network.backup_ip != None and network.backup_ip != ""
   tags: facts
   set_fact:
     backup_ip: '{{ network.backup_ip }}'
 
 - name: Set backup IP address type (A or AAAA)
   tags: facts
-  when: network.backup_ip != ""
+  when: backup_ip is defined and backup_ip != ""
   set_fact:
     backup_ip_type: '{{ backup_ip | ipv6 | ternary("AAAA", "A") }}'
 
 - name: Check and remember if IPv6 is used
   set_fact:
     ipv6_used: >-
-      backup_ip_type == "AAAA" or
-      external_ip_type == "AAAA"
+      external_ip_type == "AAAA" or
+      (backup_ip_type is defined and backup_ip_type == "AAAA")

--- a/install/playbooks/ejabberd.yml
+++ b/install/playbooks/ejabberd.yml
@@ -3,6 +3,7 @@
 # Create the default certificate for the jabber server
 - hosts: homebox
   vars:
+    redirect: true
     certificate:
       type: '@'
   vars_files:

--- a/install/playbooks/roles/system-prepare/meta/main.yml
+++ b/install/playbooks/roles/system-prepare/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - { role: load-defaults, when: defaults_loaded is not defined }
+  - { role: external-ip-type }

--- a/install/playbooks/roles/system-prepare/tasks/main.yml
+++ b/install/playbooks/roles/system-prepare/tasks/main.yml
@@ -237,23 +237,11 @@
     path: /etc/homebox/dns-entries.d/
     state: directory
 
-# Check if IPv6 is needed or not. Otherwise, disable it entirely
-- name: Check if main IP address is IPv6 type
-  tags: facts
-  set_fact:
-    external_ip_ipv6: '{{ network.external_ip | ipv6 != False }}'
-
-- name: Check if backup IP address is IPv6 type
-  when: network.backup_ip
-  tags: facts
-  set_fact:
-    backup_ip_ipv6: '{{ network.backup_ip | ipv6 != False }}'
-
+# If IPv6 is not needed, disable it entirely
 - name: Disable IPv6 if not needed
-  when: external_ip_ipv6 == False and backup_ip_ipv6 == False
   sysctl:
     name: '{{ entry_name }}'
-    value: 1
+    value: '{{ 0 if ipv6_used else 1 }}'
   with_items:
     - net.ipv6.conf.all.disable_ipv6
     - net.ipv6.conf.default.disable_ipv6


### PR DESCRIPTION
Following the discussion in #243, I modified the changes about `backup_ip` and `backup_ip_type` accordingly and refactored the two commits concerning `system-prepare`. Details are in the commit messages.

After those changes, I guess some sanity checks on the IP addresses could be included either in the `load-defaults` role or in the `external-ip-type` role. It might allow to be more confident in the that the `external_ip` and `backup_ip` are actually IP addresses in the playbooks and templates (instead of either undefined, None, the empty string, a random string or an IP address :sweat_smile:).