### PR TITLE
Fix the determination of the ipv6_used fact

### DIFF
--- a/common/roles/external-ip-type/tasks/main.yml
+++ b/common/roles/external-ip-type/tasks/main.yml
@@ -33,6 +33,5 @@
 
 - name: Check and remember if IPv6 is used
   set_fact:
-    ipv6_used: >-
-      external_ip_type == "AAAA" or
-      (backup_ip_type is defined and backup_ip_type == "AAAA")
+    ipv6_used: '{{ external_ip_type == "AAAA" or
+                   (backup_ip_type is defined and backup_ip_type == "AAAA") }}'


### PR DESCRIPTION
Fix for the commit 759e673 merged with #252.

The jinja expression needs to be enclosed in braces (`{{…}}`) to be
evaluated.

Remove the multiline operator as it returned a quoted string instead of
getting the boolean value, and the enclosed jinja expression can be
split on several lines.