### PR TITLE
bind: use minimal ANY responses

### DIFF
--- a/install/playbooks/roles/dns-server-bind/templates/named.conf.options
+++ b/install/playbooks/roles/dns-server-bind/templates/named.conf.options
@@ -166,5 +166,6 @@ options {
     //========================================================================
     dnssec-validation auto;
     auth-nxdomain no;    # conform to RFC1035
+    minimal-any yes;
     listen-on-v6 { any; };
 };


### PR DESCRIPTION
From bind 9.11, the option `minimal-any` is available to reduce the size
of the ANY responses over UDP, and limit the possibility of traffic
amplification.

With `minimal-any yes`, Bind returns a single record (the first one it
can find) for ANY requests over UDP. TCP responses are unfiltered.

This behavior is described in RFC8482, 4.1:
https://tools.ietf.org/html/rfc8482#section-4.1

The `dig` command uses TCP by default for ANY requests, so be sure to
test with the option `+notcp`.