### PR TITLE
bind: extra records

### DIFF
--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -92,6 +92,12 @@
     dest: '/etc/bind/reverse-backup.{{ network.domain }}'
     mode: '0640'
 
+- name: Add extra records
+  when: bind.extra_records != []
+  template:
+    src: extra-records.conf
+    dest: /etc/homebox/dns-entries.d/90-extra-records.bind
+
 - name: Build the final bind configuration
   tags: config
   assemble:
@@ -290,10 +296,3 @@
   with_items:
     - '*.key'
     - '*.private'
-
-# Add extra records ===========================================================
-- name: Add extra records
-  when: bind.extra_records != []
-  template:
-    src: extra-records.conf
-    dest: /etc/homebox/dns-entries.d/90-extra-records.bind

--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -98,6 +98,12 @@
     src: extra-records.conf
     dest: /etc/homebox/dns-entries.d/90-extra-records.bind
 
+- name: Make sure extra records are absent if not needed
+  when: bind.extra_records == []
+  file:
+    path: /etc/homebox/dns-entries.d/90-extra-records.bind
+    state: absent
+
 - name: Build the final bind configuration
   tags: config
   assemble:


### PR DESCRIPTION
Add or remove the configuration file for the extra records before the bind forward zone configuration is assembled. Allow for reconfiguration if adding or removing records.