### PR TITLE
Draft: borgbackup: server backup location

### DIFF
--- a/docs/backup-home.md
+++ b/docs/backup-home.md
@@ -33,7 +33,7 @@ backup:
   - name: nas1
     automount: true
     uuid: 6e2cd39d-1109-43de-aee5-a6491fdec689
-    url: usb:///mnt/backup/nas1/homebox
+    url: usb:///homebox
     active: yes                      # The backup is currently active
     frequency: daily                 # Run the backup every day
     keep_daily: 3                    # Keep the last three days locally
@@ -162,17 +162,19 @@ backup
   - name: nas1
     automount: true
     uuid: 6d83f6d4-2769-46d0-b07b-675ab0863393
-    url: usb:///mnt/backup/nas1/homebox-backup
+    url: usb:///homebox-backup
     active: yes                      # The backup is currently active
     frequency: daily                 # Run the backup every day
     keep_daily: 3                    # Keep the last three days locally
     compression: lz4                 # Use the fast compression for daily backups
 ```
 
-The exact syntax for the url takes one drive name and an optional directory name. You can have
-multiple backups on the same device, by using a different sub-directory:
+The URL represents the path on the USB drive. You can have multiple backups on
+the same device, by using different directories:
 
-`url: usb:///mnt/backup/<drive-name>[/sub-directory]`
+`url: usb:///[directory]`
+
+`url: usb:///[some/][other/][backup/][directory]`
 
 The filesystem UUID should be specified, and the initial folder should already exist on the
 external device. To obtain the UUID of your external drive, use blkid command. You do not need to
@@ -211,7 +213,7 @@ backup:
   ...
   - name: s3main
     automount: true
-    url: s3fs:///mnt/backup/s3main/homebox
+    url: s3fs:///homebox
     active: yes
     frequency: weekly
     keep_weekly: 4

--- a/install/playbooks/roles/borg-backup/files/backup.py
+++ b/install/playbooks/roles/borg-backup/files/backup.py
@@ -155,14 +155,14 @@ class BackupManager(object):
         # for this scheme, it is assumed that the remote server has borg
         # installed otherwise, use sshfs://
         if self.location.scheme == 'ssh':
-            self.repositoryPath = self.url[6:]
+            self.repositoryPath = self.url[6:] + '/@server'
             self.repositoryMounted = False
             return True
 
         # The dir:// backup location can be a remote directory mounted locally
         # or even a local partition.
         if self.location.scheme == 'dir':
-            self.repositoryPath = self.location.path
+            self.repositoryPath = self.location.path + '/@server'
             self.repositoryMounted = False
             os.makedirs(self.location.path, exist_ok=True)
             return True
@@ -171,7 +171,7 @@ class BackupManager(object):
         if self.location.scheme in {'usb', 's3fs', 'sshfs'}:
             # Make sure the directory to mount the backup exists
             self.mountPath = '/mnt/backup/' + self.configName
-            self.repositoryPath = self.mountPath
+            self.repositoryPath = self.mountPath + '/@server'
             self.repositoryMounted = True
             os.makedirs(self.mountPath, exist_ok=True)
             return True

--- a/install/playbooks/roles/borg-backup/files/backup.py
+++ b/install/playbooks/roles/borg-backup/files/backup.py
@@ -156,14 +156,14 @@ class BackupManager(object):
         # installed otherwise, use sshfs://
         if self.location.scheme == 'ssh':
             self.repositoryPath = self.url[6:]
-            self.repositoryMounted = True
+            self.repositoryMounted = False
             return True
 
         # The dir:// backup location can be a remote directory mounted locally
         # or even a local partition.
         if self.location.scheme == 'dir':
             self.repositoryPath = self.location.path
-            self.repositoryMounted = True
+            self.repositoryMounted = False
             os.makedirs(self.location.path, exist_ok=True)
             return True
 
@@ -185,12 +185,6 @@ class BackupManager(object):
     def umountRepository(self):
         """Umount the remote location if necessary"""
         if not self.repositoryMounted:
-            return True
-
-        # Local directories are never mounted
-        if self.location.scheme == 'dir' or self.location.scheme == 'ssh':
-            self.repositoryPath = None
-            self.repositoryMounted = False
             return True
 
         # umount the current location

--- a/install/playbooks/roles/borg-backup/files/backup.py
+++ b/install/playbooks/roles/borg-backup/files/backup.py
@@ -172,9 +172,9 @@ class BackupManager(object):
             # Make sure the directory to mount the backup exists
             self.mountPath = '/mnt/backup/' + self.configName
             self.repositoryPath = self.mountPath + '/@server'
-            self.repositoryMounted = True
+            self.repositoryMounted = os.path.ismount(self.mountPath)
             os.makedirs(self.mountPath, exist_ok=True)
-            return True
+            return self.repositoryMounted
 
         # Throw an error in case the protocol is not implemented
         logging.error("Unknown or not implemented scheme %s", self.location)

--- a/install/playbooks/roles/borg-backup/files/backup.py
+++ b/install/playbooks/roles/borg-backup/files/backup.py
@@ -164,27 +164,24 @@ class BackupManager(object):
         if self.location.scheme == 'dir':
             self.repositoryPath = self.location.path + '/@server'
             self.repositoryMounted = False
-            os.makedirs(self.location.path, exist_ok=True)
             return True
+
+        # Make sure the directory to mount the backup exists
+        self.mountPath = '/mnt/backup/' + self.configName
+        os.makedirs(self.mountPath, exist_ok=True)
 
         # These locations are mounted automatically using systemd
         if self.location.scheme in {'cifs', 'sshfs'}:
-            # Make sure the directory to mount the backup exists
-            self.mountPath = '/mnt/backup/' + self.configName
             # The target directories are directly mounted at the mountPath.
             self.repositoryPath = self.mountPath + '/@server'
-            os.makedirs(self.repositoryPath, exist_ok=True)
             self.repositoryMounted = os.path.ismount(self.mountPath)
             return self.repositoryMounted
 
         # These locations are mounted automatically using systemd
         if self.location.scheme in {'s3fs', 'usb'}:
-            # Make sure the directory to mount the backup exists
-            self.mountPath = '/mnt/backup/' + self.configName
             # The root of the remote filesystem is mounted at the mountPath,
             # add the location path part to reflect the given URL.
             self.repositoryPath = self.mountPath + self.location.path + '/@server'
-            os.makedirs(self.repositoryPath, exist_ok=True)
             self.repositoryMounted = os.path.ismount(self.mountPath)
             return self.repositoryMounted
 

--- a/install/playbooks/roles/borg-backup/files/backup.py
+++ b/install/playbooks/roles/borg-backup/files/backup.py
@@ -155,7 +155,7 @@ class BackupManager(object):
         # for this scheme, it is assumed that the remote server has borg
         # installed otherwise, use sshfs://
         if self.location.scheme == 'ssh':
-            self.repositoryPath = self.url[6:] + '/@server'
+            self.repositoryPath = self.url + '/@server'
             self.repositoryMounted = False
             return True
 


### PR DESCRIPTION
WIP attempt to see if it would be possible to move the backup folders and repos of the users created by the `backup-server` playbook from the backup repo of the server.

Currently, the layout uses:
- a backup name;
- a location: local with `dir` or remote with `ssh`, `usb`, `cifs`, `s3fs`;
- a mount point: `/mnt/backup/<name>` for `usb`, `cifs`, `s3fs`;
- a repository path: the location for `dir` and `ssh`, the mount point for `usb`, `cifs`, `s3fs`.

A borg repository is initialized at the repository path for the server backups.
Folders for user backups are created under the repository path for storing user created borg repos. I assume this is to avoid having the borg backup on the server processing already existing borg repositories (a lot of unnecessary hash computations).
```
# ls -1F <repository path>
config
data/
<uid1>/
<uid2>/
hints.145
index.145
integrity.145
nonce
README
```

To avoid adding directories inside the repo directory controlled by borg, the idea would be to separate the mount point / location from the repository path, and use a layout such as:
```
# ls -1F <mount point | location>
@server/
<uid1>/
<uid2>/
```
The `@server` directory being the borg repository for the server backup. The `@` is there to avoid naming conflicts as it cannot be used in a UID.

The 'server' name is arbitrary, it could as well be 'homebox'. The assumption is that these directories will be stored under a (remote) directory already identifying the server. Naming it '{{ network.domain }}' might be redundant.

The first two commit are unifying the locations and paths handling in `mountRepository`, and are applicable to the current code and layout.

On the todo list:
- [x] test `dir` locations repo actions;
- [x] test `ssh` locations;
- [ ] test remote mounted locations (`usb`, `cifs`, `s3fs`);
  - [x] `usb`
  - [ ] `cifs`
  - [ ] `s3fs`
- [ ] add tasks for an upgrade path from the current to the new layout;
  - if a repo exists at <mount point | location>
    - create a `@server` directory
    - move borg files to the `@server` directory
    - clean the borg cache in `/root/.cache/borg` (to avoid the prompt that the repo was known to be at a different location during backup actions)
