### PR TITLE
WiP: An attept to reduce the certificate permissions

### DIFF
--- a/common/roles/cert-perms/tasks/main.yml
+++ b/common/roles/cert-perms/tasks/main.yml
@@ -31,10 +31,3 @@
       - '/etc/letsencrypt/live/{{ cert_dir }}'
   loop_control:
     loop_var: path
-
-- name: Allow the full chain to be read
-  tags: cert
-  shell: >-
-    chmod a+r /etc/letsencrypt/archive/{{ cert_dir }}/fullchain*.pem
-  args:
-    warn: false

--- a/common/roles/cert-perms/tasks/main.yml
+++ b/common/roles/cert-perms/tasks/main.yml
@@ -2,7 +2,7 @@
 
 # Posix permissions
 
-- name: Set the unix mode for thecertificate files readable by root only
+- name: Set the unix mode for the certificate files readable by root only
   tags: cert
   file:
     path: '{{ path }}'
@@ -16,7 +16,7 @@
   loop_control:
     loop_var: path
 
-- name: Set the unix mode for the directory readable by root only
+- name: Set the unix mode for the directory accessible by root only
   tags: cert
   file:
     path: '{{ path }}'
@@ -48,7 +48,7 @@
   loop_control:
     loop_var: path
 
-- name: Set the acl permissions for the directory
+- name: Set the acl permissions for the directory itself
   tags: cert
   acl:
     path: '{{ path }}'
@@ -63,7 +63,6 @@
   loop_control:
     loop_var: path
 
-# Then, set the current permissions for the directory.
 # Then, set the default permissions for the directory.
 # The new certificates created should have the right permissions
 - name: Set the default acl for the certificate directory iself
@@ -96,7 +95,7 @@
   loop_control:
     loop_var: path
 
-- name: Set the default acl mask for the directory iself
+- name: Set the default acl mask for the files in the directory
   tags: cert
   acl:
     path: '{{ path }}'

--- a/common/roles/cert-perms/tasks/main.yml
+++ b/common/roles/cert-perms/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+
+# The loops set all files in the directories as read/write for the user (root)
+# read only for the group passed in parameter
+- name: Set the unix permissions for the certificate files
+  tags: cert
+  file:
+    path: '{{ path }}'
+    mode: '640'
+    owner: root
+    group: '{{ entity_group }}'
+    recurse: true
+  with_items:
+      - '/etc/letsencrypt/archive/{{ cert_dir }}'
+      - '/etc/letsencrypt/live/{{ cert_dir }}'
+  loop_control:
+    loop_var: path
+
+# This one sets the g+s flag, meaning that any new certificate created
+# will belongs to the group of its parent
+- name: Set the unix permissions for the certificate directory
+  tags: cert
+  file:
+    path: '{{ path }}'
+    mode: '2750'
+    owner: root
+    group: '{{ entity_group }}'
+    recurse: false
+  with_items:
+      - '/etc/letsencrypt/archive/{{ cert_dir }}'
+      - '/etc/letsencrypt/live/{{ cert_dir }}'
+  loop_control:
+    loop_var: path
+
+- name: Allow the full chain to be read
+  tags: cert
+  shell: >-
+    chmod a+r /etc/letsencrypt/archive/{{ cert_dir }}/fullchain*.pem
+  args:
+    warn: false

--- a/common/roles/cert-perms/tasks/main.yml
+++ b/common/roles/cert-perms/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 
-# The loops set all files in the directories as read/write for the user (root)
-# read only for the group passed in parameter
-- name: Set the unix permissions for the certificate files
+# Posix permissions
+
+- name: Set the unix mode for thecertificate files readable by root only
   tags: cert
   file:
     path: '{{ path }}'
-    mode: '640'
     owner: root
-    group: '{{ entity_group }}'
+    group: root
+    mode: '0600'
     recurse: true
   with_items:
       - '/etc/letsencrypt/archive/{{ cert_dir }}'
@@ -16,16 +16,95 @@
   loop_control:
     loop_var: path
 
-# This one sets the g+s flag, meaning that any new certificate created
-# will belongs to the group of its parent
-- name: Set the unix permissions for the certificate directory
+- name: Set the unix mode for the directory readable by root only
   tags: cert
   file:
     path: '{{ path }}'
-    mode: '2750'
     owner: root
-    group: '{{ entity_group }}'
+    group: root
+    mode: '0700'
     recurse: false
+  with_items:
+      - '/etc/letsencrypt/archive/{{ cert_dir }}'
+      - '/etc/letsencrypt/live/{{ cert_dir }}'
+  loop_control:
+    loop_var: path
+
+
+# First, set the acl for the files in the directory. This should cover the case
+# when the files have been synchronised
+- name: Set the acl permissions for all the certificate files in the directory
+  tags: cert
+  acl:
+    path: '{{ path }}'
+    entity: '{{ entity_group }}'
+    etype: user
+    permissions: 'r--'
+    recursive: true
+    state: present
+  with_items:
+      - '/etc/letsencrypt/archive/{{ cert_dir }}'
+      - '/etc/letsencrypt/live/{{ cert_dir }}'
+  loop_control:
+    loop_var: path
+
+- name: Set the acl permissions for the directory
+  tags: cert
+  acl:
+    path: '{{ path }}'
+    entity: '{{ entity_group }}'
+    etype: user
+    permissions: 'r-x'
+    recursive: false
+    state: present
+  with_items:
+      - '/etc/letsencrypt/archive/{{ cert_dir }}'
+      - '/etc/letsencrypt/live/{{ cert_dir }}'
+  loop_control:
+    loop_var: path
+
+# Then, set the current permissions for the directory.
+# Then, set the default permissions for the directory.
+# The new certificates created should have the right permissions
+- name: Set the default acl for the certificate directory iself
+  tags: cert
+  acl:
+    path: '{{ path }}'
+    entity: '{{ entity_group }}'
+    etype: user
+    recursive: false
+    default: yes
+    state: present
+    permissions: 'r--'
+  with_items:
+      - '/etc/letsencrypt/archive/{{ cert_dir }}'
+      - '/etc/letsencrypt/live/{{ cert_dir }}'
+  loop_control:
+    loop_var: path
+
+- name: Set the acl mask for the directory iself
+  tags: cert
+  acl:
+    path: '{{ path }}'
+    etype: mask
+    recursive: false
+    state: present
+    permissions: 'r-x'
+  with_items:
+      - '/etc/letsencrypt/archive/{{ cert_dir }}'
+      - '/etc/letsencrypt/live/{{ cert_dir }}'
+  loop_control:
+    loop_var: path
+
+- name: Set the default acl mask for the directory iself
+  tags: cert
+  acl:
+    path: '{{ path }}'
+    etype: mask
+    recursive: false
+    state: present
+    permissions: 'r-x'
+    default: true
   with_items:
       - '/etc/letsencrypt/archive/{{ cert_dir }}'
       - '/etc/letsencrypt/live/{{ cert_dir }}'

--- a/install/playbooks/roles/certificates/files/renewal-hook.sh
+++ b/install/playbooks/roles/certificates/files/renewal-hook.sh
@@ -16,10 +16,12 @@ for fqdn in $RENEWED_DOMAINS; do
         restart_nginx=$(grep -Rl "server_name $fqdn" /etc/nginx/sites-enabled/ | grep -v -e -cert -c)
     fi
 
+    # Make sure the full chain is readable by all programs
+    chmod a+r /etc/letsencrypt/archive/$fqdn/fullchain*.pem
+
     if [ "$restart_nginx" = "1" ]; then
         echo "Reloading main web site"
         systemctl restart nginx
         break
     fi
 done
-

--- a/install/playbooks/roles/certificates/files/renewal-hook.sh
+++ b/install/playbooks/roles/certificates/files/renewal-hook.sh
@@ -16,9 +16,6 @@ for fqdn in $RENEWED_DOMAINS; do
         restart_nginx=$(grep -Rl "server_name $fqdn" /etc/nginx/sites-enabled/ | grep -v -e -cert -c)
     fi
 
-    # Make sure the full chain is readable by all programs
-    chmod a+r /etc/letsencrypt/archive/$fqdn/fullchain*.pem
-
     if [ "$restart_nginx" = "1" ]; then
         echo "Reloading main web site"
         systemctl restart nginx

--- a/install/playbooks/roles/certificates/tasks/main.yml
+++ b/install/playbooks/roles/certificates/tasks/main.yml
@@ -127,6 +127,38 @@
   when: is_valid.stdout == "0"
   include_tasks: gencert.yml
 
+- name: Restrict permissions for the root of LetsEncrypt certificate directory
+  file:
+    path: '{{ path.location }}'
+    state: directory
+    mode: '{{ path.mode | default("0755") }}'
+  with_items:
+    - location: '/etc/letsencrypt'
+    - location: '/etc/letsencrypt/archive'
+    - location: '/etc/letsencrypt/live'
+    - location: '/etc/letsencrypt/archive/{{ certificate_fqdn }}'
+      mode: '0700'
+    - location: '/etc/letsencrypt/live/{{ certificate_fqdn }}'
+      mode: '0700'
+  loop_control:
+    loop_var: path
+
+- name: Allow nginx to access live and archive directories
+  tags: ssl
+  acl:
+    path: '{{ path }}'
+    entity: www-data
+    etype: user
+    permissions: rx
+    state: present
+    recursive: no
+    default: no
+  with_items:
+    - '/etc/letsencrypt/archive/{{ certificate_fqdn }}'
+    - '/etc/letsencrypt/live/{{ certificate_fqdn }}'
+  loop_control:
+    loop_var: path
+
 # In this direction, we should overwrite the symbolic links,
 # in case the certificates have been renewed
 - name: Backup the certificates on your local machine

--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -40,6 +40,14 @@
   include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
 
 - name: Set the variables for the certificate
+  set_fact:
+    cert_dir: 'ldap.{{ network.domain }}'
+    entity_group: dovecot
+
+- name: Set the default permissions for the ldap certificate folders
+  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
+
+- name: Set the variables for the certificate
   when: mail.pop3
   set_fact:
     cert_dir: 'pop3.{{ network.domain }}'

--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -31,22 +31,22 @@
 ################################################################################
 # At this point, the certificates should have been created already #############
 # in order to have SSL and TLS encryption activated.                           #
-- name: Allow slapd and nslcd daemons to access the certificate directories
-  tags: dovecot,ssl
-  notify: Restart dovecot
-  acl:
-    path: '{{ path }}'
-    entity: dovecot
-    etype: user
-    permissions: rx
-    state: present
-    recursive: yes
-    default: yes
-  with_items:
-    - /etc/letsencrypt/archive
-    - /etc/letsencrypt/live
-  loop_control:
-    loop_var: path
+- name: Set the variables for the certificate
+  set_fact:
+    cert_dir: 'imap.{{ network.domain }}'
+    entity_group: dovecot
+
+- name: Set the default permissions for the imap certificate folders
+  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
+
+- name: Set the variables for the certificate
+  set_fact:
+    cert_dir: 'pop3.{{ network.domain }}'
+    entity_group: dovecot
+
+- name: Set the default permissions for the pop3 certificate folders
+  when: mail.pop3
+  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
 
 - name: Generate a strong Diffie Hellman file
   notify: Restart dovecot

--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -40,6 +40,7 @@
   include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
 
 - name: Set the variables for the certificate
+  when: mail.pop3
   set_fact:
     cert_dir: 'pop3.{{ network.domain }}'
     entity_group: dovecot

--- a/install/playbooks/roles/dovecot/templates/dovecot-ldap.conf.ext
+++ b/install/playbooks/roles/dovecot/templates/dovecot-ldap.conf.ext
@@ -41,8 +41,10 @@ dnpass = {{ lookup("password", ldap.roPasswdParams) }}
 # dn is still the logged in user. Normally you want to keep this empty.
 #sasl_authz_id =
 
-# Use TLS to connect to the LDAP server.
-tls = yes
+# Use TLS to connect to the LDAP server is not necessary,
+# as it is on the same server. Putting yes here also seems to require
+# additional permissions for certificates sharing by dovecot.
+tls = no
 
 # TLS options, currently supported only with OpenLDAP:
 #tls_ca_cert_file =

--- a/install/playbooks/roles/dovecot/templates/dovecot-ldap.conf.ext
+++ b/install/playbooks/roles/dovecot/templates/dovecot-ldap.conf.ext
@@ -44,7 +44,7 @@ dnpass = {{ lookup("password", ldap.roPasswdParams) }}
 # Use TLS to connect to the LDAP server is not necessary,
 # as it is on the same server. Putting yes here also seems to require
 # additional permissions for certificates sharing by dovecot.
-tls = no
+tls = yes
 
 # TLS options, currently supported only with OpenLDAP:
 #tls_ca_cert_file =

--- a/install/playbooks/roles/ldap/tasks/main.yml
+++ b/install/playbooks/roles/ldap/tasks/main.yml
@@ -71,21 +71,16 @@
     loop_var: conf
 
 # Install LDAP server
+- name: Remove conflicting packages
+  tags: dpkg
+  apt:
+    name: '{{ packages.remove }}'
+    state: absent
+
 - name: Install the required packages
   tags: dpkg
-  vars:
-    pkgs:
-      - acl
-      - slapd
-      - python-ldap
-      - python-passlib
-      - ldapscripts
-      - libpam-pwquality
-      - cracklib-runtime
-      - ldapvi
-      - nscd
   apt:
-    name: '{{ pkgs }}'
+    name: '{{ packages.install }}'
     state: latest
 
 # Changes in the database will be stored there
@@ -97,22 +92,13 @@
 ################################################################################
 # At this point, the certificates should have been created already #############
 # in order to have SSL and TLS encryption activated.                           #
-- name: Allow slapd daemons to access the certificate directories
-  notify: Restart the ldap service
-  tags: cert
-  acl:
-    path: '{{ path }}'
-    entity: openldap
-    etype: user
-    permissions: rx
-    state: present
-    recursive: yes
-    default: yes
-  with_items:
-      - /etc/letsencrypt/archive
-      - /etc/letsencrypt/live
-  loop_control:
-    loop_var: path
+- name: Set the variables for the certificate
+  set_fact:
+    cert_dir: 'ldap.{{ network.domain }}'
+    entity_group: openldap
+
+- name: Set the default permissions for the imap certificate folders
+  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
 
 - name: Configure the ldap server for SSL / TLS
   notify: Restart the ldap service

--- a/install/playbooks/roles/ldap/vars/main.yml
+++ b/install/playbooks/roles/ldap/vars/main.yml
@@ -19,5 +19,3 @@ packages:
     - nscd
   remove:
     - libpam-cracklib
-    - cracklib-runtime
-    - libcrack2

--- a/install/playbooks/roles/ldap/vars/main.yml
+++ b/install/playbooks/roles/ldap/vars/main.yml
@@ -5,3 +5,19 @@ users_defaults:
   uid_start: 1001
   gid_start: 1001
   shell: /bin/dash
+
+
+packages:
+  install:
+    - acl
+    - slapd
+    - python-ldap
+    - python-passlib
+    - ldapscripts
+    - libpam-pwquality
+    - ldapvi
+    - nscd
+  remove:
+    - libpam-cracklib
+    - cracklib-runtime
+    - libcrack2

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -11,22 +11,13 @@
 ################################################################################
 # At this point, the certificates should have been created already #############
 # in order to have SSL and TLS encryption activated.                           #
-- name: Allow postfix to access the certificate directories
-  tags: postfix,ssl
-  notify: Restart postfix
-  acl:
-    path: '{{ path }}'
-    entity: postfix
-    etype: user
-    permissions: rx
-    state: present
-    recursive: yes
-    default: yes
-  with_items:
-    - /etc/letsencrypt/archive
-    - /etc/letsencrypt/live
-  loop_control:
-    loop_var: path
+- name: Set the variables for the certificate permissions
+  set_fact:
+    cert_dir: 'smtp.{{ network.domain }}'
+    entity_group: postfix
+
+- name: Set the default permissions for the imap certificate folders
+  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
 
 - name: Copy the certificate renewal hook
   tags: cert

--- a/install/playbooks/roles/system-post-install/tasks/partitions-security.yml
+++ b/install/playbooks/roles/system-post-install/tasks/partitions-security.yml
@@ -4,6 +4,8 @@
 - name: Check if /tmp is a mount point
   register: tmp_mountpoint_cmd
   shell: mountpoint -q /tmp/
+  failed_when: false
+  changed_when: false
   args:
     warn: false
 
@@ -32,6 +34,8 @@
 - name: Check if /boot is a mount point
   register: boot_mountpoint_cmd
   shell: mountpoint -q /boot/
+  failed_when: false
+  changed_when: false
   args:
     warn: false
 
@@ -60,6 +64,8 @@
 - name: Check if /home is a mount point
   register: home_mountpoint_cmd
   shell: mountpoint -q /home/
+  failed_when: false
+  changed_when: false
   args:
     warn: false
 

--- a/tests/playbooks/roles/dev-support/tasks/main.yml
+++ b/tests/playbooks/roles/dev-support/tasks/main.yml
@@ -24,4 +24,3 @@
   user:
     name: root
     shell: '{{ devel.root.shell }}'
-


### PR DESCRIPTION
The certificates should be readable only by their counterparts
programs, for instance, imap / pop3 by dovecot, smtp by postfix,
etc...

This should fix #259