### PR TITLE
dovecot: script-login access to security limits

### DIFF
--- a/install/playbooks/roles/dovecot/templates/apparmor.d/usr.lib.dovecot.script-login
+++ b/install/playbooks/roles/dovecot/templates/apparmor.d/usr.lib.dovecot.script-login
@@ -112,6 +112,7 @@
   # Access configuration files
   /etc/passwd r,
   /etc/security/limits.d/ r,
+  /etc/security/limits.d/* r,
   /etc/nsswitch.conf r,
   /etc/environment r,
   /etc/default/locale r,


### PR DESCRIPTION
Calls to `su` in the `dovecot-postlogin` script called by `script login`
try to access the files in the `/etc/security/limits.d/` folder.

Allow access to those files in the apparmor profile for `script-login`.