### PR TITLE
Ansible-lint more errors and warnings

### DIFF
--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -22,3 +22,6 @@ ansible-lint install/playbooks/main.yml | tee logs/ansible-lint-install.log
 
 # Run ansible lint on the test playbooks
 ansible-lint tests/playbooks/main.yml | tee logs/ansible-lint-tests.log
+
+# Run ansible lint on the uninstall playbooks
+ansible-lint uninstall/playbooks/*.yml | tee logs/ansible-lint-uninstall.log

--- a/tests/playbooks/roles/https-grade/tasks/main.yml
+++ b/tests/playbooks/roles/https-grade/tasks/main.yml
@@ -6,8 +6,7 @@
     name: lynx
 
 - name: Check all https security grades
-  include_tasks:
-    file: test-cert.yml
+  include_tasks: test-cert.yml
   with_items:
     - '{{ tests | selectattr("condition", "equalto", true) | list }}'
   loop_control:

--- a/uninstall/playbooks/roles/transmission/tasks/main.yml
+++ b/uninstall/playbooks/roles/transmission/tasks/main.yml
@@ -62,13 +62,15 @@
 # Remove firewall rules =======================================================
 - name: Clean up firewall rules
   shell: >-
+    set -o pipefail ;
     ufw status numbered
     | grep transmission
     | sed -r 's/^\[(..)\] .*/echo y | ufw delete \1/'
     | sort -r | sh
   args:
+    executable: /bin/bash
     warn: no
-    
+
 # AppArmor configuration ======================================================
 
 - name: Remove nginx and transmission AppArmor profiles


### PR DESCRIPTION
Address a warning in the https-grade playbook.

Lint the uninstall playbooks.