### PR TITLE
Replace nscd by unscd

### DIFF
--- a/install/playbooks/roles/ldap/vars/main.yml
+++ b/install/playbooks/roles/ldap/vars/main.yml
@@ -16,6 +16,7 @@ packages:
     - ldapscripts
     - libpam-pwquality
     - ldapvi
-    - nscd
+    - unscd
   remove:
     - libpam-cracklib
+    - nscd


### PR DESCRIPTION
This removed all the apparmor errors in the logs, like
"var/cache/nscd/...". Same bug on buster.