### PR TITLE
cert-perms: set www-data access per playbook

### DIFF
--- a/install/playbooks/mta-sts.yml
+++ b/install/playbooks/mta-sts.yml
@@ -13,8 +13,5 @@
   roles:
     - role: certificates
       tags: certificates
-
-- hosts: homebox
-  roles:
     - role: mta-sts
       tags: mta-sts

--- a/install/playbooks/roles/autoconfig/tasks/main.yml
+++ b/install/playbooks/roles/autoconfig/tasks/main.yml
@@ -40,6 +40,15 @@
     dest: '/etc/nginx/sites-enabled/autoconfig.{{ network.domain }}.conf'
     state: link
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ certificate.type }}.{{ network.domain }}'
+    entity_group: 'www-data'
+
 # AppArmor configuration ======================================================
 
 - name: Install nginx AppArmor profile

--- a/install/playbooks/roles/autodiscover/tasks/main.yml
+++ b/install/playbooks/roles/autodiscover/tasks/main.yml
@@ -36,6 +36,15 @@
     dest: '/etc/nginx/sites-enabled/autodiscover.{{ network.domain }}.conf'
     state: link
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ certificate.type }}.{{ network.domain }}'
+    entity_group: 'www-data'
+
 # AppArmor configuration ======================================================
 
 - name: Install nginx AppArmor profile

--- a/install/playbooks/roles/certificates/tasks/main.yml
+++ b/install/playbooks/roles/certificates/tasks/main.yml
@@ -146,22 +146,6 @@
   loop_control:
     loop_var: path
 
-- name: Allow nginx to access live and archive directories
-  tags: ssl
-  acl:
-    path: '{{ path }}'
-    entity: www-data
-    etype: user
-    permissions: rx
-    state: present
-    recursive: no
-    default: no
-  with_items:
-    - '/etc/letsencrypt/archive/{{ certificate_fqdn }}'
-    - '/etc/letsencrypt/live/{{ certificate_fqdn }}'
-  loop_control:
-    loop_var: path
-
 # In this direction, we should overwrite the symbolic links,
 # in case the certificates have been renewed
 - name: Backup the certificates on your local machine

--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -31,31 +31,27 @@
 ################################################################################
 # At this point, the certificates should have been created already #############
 # in order to have SSL and TLS encryption activated.                           #
-- name: Set the variables for the certificate
-  set_fact:
+- name: Set the default permissions for the imap certificate folders
+  import_role:
+    name: cert-perms
+  vars:
     cert_dir: 'imap.{{ network.domain }}'
     entity_group: dovecot
 
-- name: Set the default permissions for the imap certificate folders
-  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
-
-- name: Set the variables for the certificate
-  set_fact:
-    cert_dir: 'ldap.{{ network.domain }}'
-    entity_group: dovecot
-
 - name: Set the default permissions for the ldap certificate folders
-  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
-
-- name: Set the variables for the certificate
-  when: mail.pop3
-  set_fact:
-    cert_dir: 'pop3.{{ network.domain }}'
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: 'ldap.{{ network.domain }}'
     entity_group: dovecot
 
 - name: Set the default permissions for the pop3 certificate folders
   when: mail.pop3
-  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: 'pop3.{{ network.domain }}'
+    entity_group: dovecot
 
 - name: Generate a strong Diffie Hellman file
   notify: Restart dovecot

--- a/install/playbooks/roles/gogs/tasks/main.yml
+++ b/install/playbooks/roles/gogs/tasks/main.yml
@@ -149,6 +149,14 @@
     dest: '/etc/nginx/sites-enabled/gogs.{{ network.domain }}.conf'
     state: link
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ certificate.type }}.{{ network.domain }}'
+    entity_group: 'www-data'
 
 # AppArmor configuration ======================================================
 

--- a/install/playbooks/roles/ldap/tasks/main.yml
+++ b/install/playbooks/roles/ldap/tasks/main.yml
@@ -92,13 +92,12 @@
 ################################################################################
 # At this point, the certificates should have been created already #############
 # in order to have SSL and TLS encryption activated.                           #
-- name: Set the variables for the certificate
-  set_fact:
+- name: Set the default permissions for the imap certificate folders
+  import_role:
+    name: cert-perms
+  vars:
     cert_dir: 'ldap.{{ network.domain }}'
     entity_group: openldap
-
-- name: Set the default permissions for the imap certificate folders
-  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
 
 - name: Configure the ldap server for SSL / TLS
   notify: Restart the ldap service

--- a/install/playbooks/roles/mta-sts/tasks/main.yml
+++ b/install/playbooks/roles/mta-sts/tasks/main.yml
@@ -48,6 +48,15 @@
     src: 35-mta-sts.bind
     dest: /etc/homebox/dns-entries.d/35-mta-sts.bind
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ certificate.type }}.{{ network.domain }}'
+    entity_group: 'www-data'
+
 # AppArmor configuration ======================================================
 
 - name: Install nginx AppArmor profile

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -11,13 +11,12 @@
 ################################################################################
 # At this point, the certificates should have been created already #############
 # in order to have SSL and TLS encryption activated.                           #
-- name: Set the variables for the certificate permissions
-  set_fact:
+- name: Set the default permissions for the imap certificate folders
+  import_role:
+    name: cert-perms
+  vars:
     cert_dir: 'smtp.{{ network.domain }}'
     entity_group: postfix
-
-- name: Set the default permissions for the imap certificate folders
-  include_tasks: '{{ playbook_dir }}/../../common/roles/cert-perms/tasks/main.yml'
 
 - name: Copy the certificate renewal hook
   tags: cert

--- a/install/playbooks/roles/roundcube/tasks/main.yml
+++ b/install/playbooks/roles/roundcube/tasks/main.yml
@@ -38,6 +38,17 @@
     dest: '/etc/nginx/sites-enabled/webmail.{{ network.domain }}.conf'
     state: link
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ certificate.type }}.{{ network.domain }}'
+    entity_group: 'www-data'
+
+# =============================================================================
+
 - name: Create a session key for roundcube
   tags: password
   notify: Restart nginx

--- a/install/playbooks/roles/rspamd-web/tasks/main.yml
+++ b/install/playbooks/roles/rspamd-web/tasks/main.yml
@@ -25,6 +25,14 @@
     dest: '/etc/nginx/sites-enabled/rspamd.{{ network.domain }}.conf'
     state: link
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ certificate.type }}.{{ network.domain }}'
+    entity_group: 'www-data'
 
 # AppArmor configuration ======================================================
 

--- a/install/playbooks/roles/sogo/tasks/main.yml
+++ b/install/playbooks/roles/sogo/tasks/main.yml
@@ -37,6 +37,15 @@
     dest: '/etc/nginx/sites-enabled/sogo.{{ network.domain }}.conf'
     state: link
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ certificate.type }}.{{ network.domain }}'
+    entity_group: 'www-data'
+
 # Database configuration ======================================================
 
 - name: Initialise the sogo database password parameters

--- a/install/playbooks/roles/transmission/tasks/main.yml
+++ b/install/playbooks/roles/transmission/tasks/main.yml
@@ -41,6 +41,15 @@
     dest: '/etc/nginx/sites-enabled/transmission.{{ network.domain }}.conf'
     state: link
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ certificate.type }}.{{ network.domain }}'
+    entity_group: 'www-data'
+
 # nginx Fancyindex ============================================================
 - name: Install the nginx fancyindex package
   tags: apt

--- a/install/playbooks/roles/website-simple/tasks/main.yml
+++ b/install/playbooks/roles/website-simple/tasks/main.yml
@@ -104,6 +104,22 @@
     dest: /etc/nginx/sites-enabled/www.{{ network.domain }}.conf
     state: link
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the www certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: 'www.{{ network.domain }}'
+    entity_group: 'www-data'
+
+- name: Set permissions for www-data to the domain certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ network.domain }}'
+    entity_group: 'www-data'
+
 # AppArmor configuration ======================================================
 
 - name: Install web site AppArmor profile

--- a/install/playbooks/roles/well-known-services/tasks/main.yml
+++ b/install/playbooks/roles/well-known-services/tasks/main.yml
@@ -38,3 +38,12 @@
     src: /etc/nginx/sites-available/catchall.conf
     dest: /etc/nginx/sites-enabled/catchall.conf
     state: link
+
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ network.domain }}'
+    entity_group: 'www-data'

--- a/install/playbooks/roles/zabbix-server/tasks/main.yml
+++ b/install/playbooks/roles/zabbix-server/tasks/main.yml
@@ -59,6 +59,15 @@
     dest: '/etc/nginx/sites-enabled/zabbix.{{ network.domain }}.conf'
     state: link
 
+# TLS certificate access ======================================================
+
+- name: Set permissions for www-data to the certificate folder
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: '{{ certificate.type }}.{{ network.domain }}'
+    entity_group: 'www-data'
+
 # AppArmor configuration ======================================================
 
 - name: Install nginx AppArmor profile

--- a/install/playbooks/zabbix.yml
+++ b/install/playbooks/zabbix.yml
@@ -11,12 +11,5 @@
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
     - certificates
-
-# Install the zabbix server
-- hosts: homebox
-  vars_files:
-    - '{{ playbook_dir }}/../../config/system.yml'
-    - '{{ playbook_dir }}/../../config/defaults.yml'
-  roles:
     - php-fpm
     - zabbix-server


### PR DESCRIPTION
Set `wwww-data` access to the certificates using the `cert-perms` role
in each playbook needing it.

Use `import_role` to call the `cert-perms` role.