### PR TITLE
Fixed an error when IPv6 is not used

### DIFF
--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -27,6 +27,15 @@
       - dnsutils
     state: present
 
+- name: Get bind minor version
+  register: bind_minor_version
+  shell: >-
+    set -o pipefail ;
+    bind9-config --version
+    | sed -En 's/.*=9\.([0-9]+).*/\1/p'
+  args:
+    executable: /bin/bash
+
 - name: Stop the DNS server before creating the configuration
   service:
     name: bind9

--- a/install/playbooks/roles/dns-server-bind/templates/named.conf.options
+++ b/install/playbooks/roles/dns-server-bind/templates/named.conf.options
@@ -166,6 +166,10 @@ options {
     //========================================================================
     dnssec-validation auto;
     auth-nxdomain no;    # conform to RFC1035
-    minimal-any yes;
+{% if ipv6_used %}
     listen-on-v6 { any; };
+{% endif %}
+{% if (bind_minor_version.stdout|int) >= 11 %}
+    minimal-any yes;
+{% endif %}
 };


### PR DESCRIPTION
bind9 support the option "minimal-any" only starting with minor version 11.