### PR TITLE
Use the length filter to test a non-empty string

### DIFF
--- a/common/roles/external-ip-type/tasks/main.yml
+++ b/common/roles/external-ip-type/tasks/main.yml
@@ -20,14 +20,14 @@
 
 # Backup IP address if defined
 - name: Get the backup IP address
-  when: network.backup_ip != None and (network.backup_ip | bool)
+  when: network.backup_ip != None and (network.backup_ip | length > 0)
   tags: facts
   set_fact:
     backup_ip: '{{ network.backup_ip }}'
 
 - name: Set backup IP address type (A or AAAA)
   tags: facts
-  when: backup_ip is defined and (backup_ip | bool)
+  when: backup_ip is defined and (backup_ip | length > 0)
   set_fact:
     backup_ip_type: '{{ backup_ip | ipv6 | ternary("AAAA", "A") }}'
 

--- a/install/playbooks/roles/borg-backup/tasks/restore-all.yml
+++ b/install/playbooks/roles/borg-backup/tasks/restore-all.yml
@@ -40,7 +40,7 @@
   become: true
   become_user: sogo
   become_method: sudo
-  when: sogo.install and not sogo_backup_dir.changed and (sogo_last_backup_dir.stdout | bool)
+  when: sogo.install and not sogo_backup_dir.changed and (sogo_last_backup_dir.stdout | length > 0)
   notify: Restart memcached
   shell: >-
     test -f /var/backups/sogo/{{ sogo_last_backup_dir.stdout }}/{{ user.uid }} &&

--- a/install/playbooks/roles/certificates/tasks/gencert.yml
+++ b/install/playbooks/roles/certificates/tasks/gencert.yml
@@ -19,7 +19,7 @@
     --webroot
     --webroot-path "{{ site_root }}"
     --domain "{{ certificate_fqdn }}"
-    {{ "-d " + domain_alias + "." + network.domain if domain_alias is defined and (domain_alias | bool) else "" }}
+    {{ "-d " + domain_alias + "." + network.domain if domain_alias is defined and (domain_alias | length > 0) else "" }}
     --email "admin@{{ network.domain }}"
     {{ domain_alias_cmd is defined | ternary("--expand", "") }}
     {{ system.devel | ternary("--test-cert", "") }}

--- a/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind-refresh/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: Copy DNS entries in bind cache directory (reverse for backup IP)
   notify: Restart bind
-  when: bind.generate_reverse and backup_ip is defined and (backup_ip | bool)
+  when: bind.generate_reverse and backup_ip is defined and (backup_ip | length > 0)
   copy:
     src: '/etc/bind/reverse-backup.{{ network.domain }}'
     dest: '/var/cache/bind/reverse-backup.{{ network.domain }}'

--- a/install/playbooks/roles/dns-server-bind/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-bind/tasks/main.yml
@@ -50,7 +50,7 @@
 
 # Backup IP address
 - name: Build the reverse IP address (works for IPv4 or IPv6)
-  when: backup_ip is defined and (backup_ip | bool)
+  when: backup_ip is defined and (backup_ip | length > 0)
   tags: facts
   set_fact:
     reverse_backup_ip: "{{ backup_ip | ipaddr('revdns') }}"
@@ -90,7 +90,7 @@
     mode: '0640'
 
 - name: Copy the backup reverse configuration template
-  when: bind.generate_reverse and backup_ip is defined and (backup_ip | bool)
+  when: bind.generate_reverse and backup_ip is defined and (backup_ip | length > 0)
   tags: config
   vars:
     serial: "{{ lookup('pipe', 'date +%s') }}"
@@ -282,7 +282,7 @@
     remote_src: true
 
 - name: Copy DNS entries in bind cache directory (reverse for backup IP)
-  when: bind.generate_reverse and backup_ip is defined and (backup_ip | bool)
+  when: bind.generate_reverse and backup_ip is defined and (backup_ip | length > 0)
   copy:
     src: '/etc/bind/reverse-backup.{{ network.domain }}'
     dest: '/var/cache/bind/reverse-backup.{{ network.domain }}'
@@ -302,7 +302,7 @@
     line: '127.0.0.1    main.{{ network.domain }}'
 
 - name: Ensure the backup record resolves to me
-  when: backup_ip is defined and (backup_ip | bool)
+  when: backup_ip is defined and (backup_ip | length > 0)
   tags: hosts
   lineinfile:
     path: /etc/hosts

--- a/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
+++ b/install/playbooks/roles/dns-server-check-propagation/tasks/main.yml
@@ -12,7 +12,7 @@
 # This is checking that the DNS server has been fully propagated
 - name: Check DNS propagation for backup IP address
   register: backup_ip_check
-  when: backup_ip is defined and (backup_ip | bool)
+  when: backup_ip is defined and (backup_ip | length > 0)
   shell: >-
     host backup.{{ network.domain }}
   retries: '{{ bind.propagation.retries | default(10) }}'

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -216,7 +216,7 @@
     spf_senders: '{{ "ip6:" + external_ip if external_ip | ipv6 else "ip4:" + external_ip }}'
 
 - name: Add the backup IP address as SPF sender
-  when: backup_ip is defined and (backup_ip | bool)
+  when: backup_ip is defined and (backup_ip | length > 0)
   tags: spf
   set_fact:
     spf_senders: '{{ spf_senders }} {{ "ip6:" + backup_ip if backup_ip | ipv6 else "ip4:" + backup_ip }}'

--- a/tests/playbooks/roles/tor/tasks/main.yml
+++ b/tests/playbooks/roles/tor/tasks/main.yml
@@ -37,7 +37,7 @@
   args:
     warn: false
     executable: /bin/bash
-  failed_when: direct_ip.stdout == proxied_ip.stdout or not (proxied_ip.stdout | bool)
+  failed_when: direct_ip.stdout == proxied_ip.stdout or not (proxied_ip.stdout | length > 0)
   changed_when: false
 
 - name: Check Tor with the official site


### PR DESCRIPTION
Address ansible-lint E602 error "Don't compare to empty string" with the
test `| length > 0`.

The filter `| bool` gives the boolean value `True` only if the string is
one of `"true"`, `"True"`, `"yes"`, `"1"`, or other strings meaning
`True`. Any other non-empty string is translated to `False`.

The current recommended solution, to use the bare variable, gives
deprecation warnings now.

After reading the related discussions, this might be the current best
workaround:
https://github.com/ansible/ansible-lint/issues/457
https://stackoverflow.com/a/59085721

Keep legitimate uses of `| bool` in access-check scripts.