### PR TITLE
Split DMARC text records on multiple lines

### DIFF
--- a/install/playbooks/roles/opendmarc/templates/20-dmarc.bind
+++ b/install/playbooks/roles/opendmarc/templates/20-dmarc.bind
@@ -1,2 +1,9 @@
-;; OpenDMARC record
-_dmarc 3600 IN TXT "v=DMARC1; p={{ dmarc.domain.policy }}; sp={{ dmarc.domain.policy }}; adkim={{ dmarc.dkim_align[0] }}; rua=mailto:{{ dmarc.rua.email }}!{{ dmarc.rua.max_size }}; ruf=mailto:{{ dmarc.ruf.email }}!{{ dmarc.ruf.max_size }}; rf={{ dmarc.reporting.format }}; pct={{ dmarc.reporting.percent }}; ri={{ dmarc.reporting.interval }}"
+;; OpenDMARC record.
+;; This is split on multiple lines, to make sure it does not
+;; extend 255 characters when the domain name is long.
+_dmarc 3600 IN TXT ("v=DMARC1; p={{ dmarc.domain.policy }};"
+    "sp={{ dmarc.domain.policy }};adkim={{ dmarc.dkim_align[0] }};"
+    "rua=mailto:{{ dmarc.rua.email }}!{{ dmarc.rua.max_size }};"
+    "ruf=mailto:{{ dmarc.ruf.email }}!{{ dmarc.ruf.max_size }};"
+    "rf={{ dmarc.reporting.format }}; pct={{ dmarc.reporting.percent }};"
+    "ri={{ dmarc.reporting.interval }}")


### PR DESCRIPTION
This is necessary when the domain name is long and generate a record
longer than 255 characters.