### PR TITLE
Fix ansible-lint warning on include_tasks

### DIFF
--- a/install/playbooks/roles/access-report/tasks/main.yml
+++ b/install/playbooks/roles/access-report/tasks/main.yml
@@ -18,8 +18,7 @@
     mode: '0755'
 
 - name: Add cron tasks for each users
-  include_tasks:
-    file: cron-tasks.yml
+  include_tasks: cron-tasks.yml
   with_items:
     - '{{ users | selectattr("access_report", "defined") | list }}'
     - uid: postmaster


### PR DESCRIPTION
Avoid messages like:
```
WARNING: Couldn't open /[…]/install/playbooks/roles/access-report/tasks/{'file': - No such file or directory
```