### PR TITLE
sogo: Create SOGo's sieve filter file

### DIFF
--- a/install/playbooks/roles/sogo/tasks/main.yml
+++ b/install/playbooks/roles/sogo/tasks/main.yml
@@ -128,6 +128,22 @@
     src: sogo.cron
     dest: '/etc/cron.d/sogo'
 
+- name: Create SOGo's sieve filters file
+  tags: config
+  when: sogo.sieve_scripts
+  file:
+    path: '/home/users/{{ user.uid }}/mails/sieve/sogo.sieve'
+    owner: '{{ user.uid }}'
+    group: 'users'
+    mode: '0600'
+    state: touch
+    modification_time: preserve
+    access_time: preserve
+  with_items:
+    - '{{ users }}'
+  loop_control:
+    loop_var: user
+
 # AppArmor configuration ======================================================
 
 - name: Install nginx AppArmor profile


### PR DESCRIPTION
Allow for the configuration of sieve filters through the SOGo user
interface. If the `sogo.sieve` file is absent, SOGo fails to add the
rules as sieve filters.

SOGo seems to correctly create the file when configuring vacation
filters. Having both (configured filters, and then activate vacation
auto-responder) might give conflicts.

See:
https://lists.inverse.ca/sogo/arc/users/2016-06/msg00198.html

And for the full discussion:
https://lists.inverse.ca/sogo/arc/users/2017-05/msg00073.html