### PR TITLE
Devel tools

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -352,6 +352,7 @@ devel_default:
     - zsh
   root:
     shell: /bin/zsh
+  acme_server: staging  # "staging" or "pebble"
 
 
 ###############################################################################

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -220,6 +220,7 @@ system_default:
   reboot_timeout: 180      # max time to wait when restarting the server
   keep_certs: false        # keep the letsencrypt certificates locally,
                            # even when using a live environment
+  apt_cacher: ~            # IP address or DNS name for an apt-cacher
 
 ###############################################################################
 # Once the system is in place, it is possible to use 'limit' for the rule,

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -438,6 +438,7 @@ bind_default:
   install: true
   # Custom delays and retries to check DNS propagation
   propagation:
+    check: true
     retries: 10
     delay: 60
   # Default servers to forward queries

--- a/devel/apt-cacher/Dockerfile
+++ b/devel/apt-cacher/Dockerfile
@@ -1,0 +1,17 @@
+# Adapted from https://docs.docker.com/engine/examples/apt-cacher-ng/
+#
+# Build: docker build -t apt-cacher .
+# Run: docker run -d -p 3142:3142 --name apt-cacher-run apt-cacher
+#
+# and then you can run containers with:
+#   docker run -t -i --rm -e http_proxy http://dockerhost:3142/ debian bash
+#
+# Here, `dockerhost` is the IP address or FQDN of a host running the Docker daemon
+# which acts as an APT proxy server.
+FROM        debian:stable
+
+VOLUME      ["/var/cache/apt-cacher-ng"]
+RUN     apt-get update && apt-get install -y apt-cacher-ng
+
+EXPOSE      3142
+CMD     chown apt-cacher-ng:root /var/cache/apt-cacher-ng && /etc/init.d/apt-cacher-ng start && tail -f /var/log/apt-cacher-ng/*

--- a/devel/docker-compose.yml
+++ b/devel/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3'
+services:
+  pebble:
+    image: letsencrypt/pebble:latest
+    # Might need '-strict false' in the future
+    command: pebble -config /test/config/pebble-config.json -dnsserver 10.30.50.3:8053
+    environment:
+      # TODO(@cpu): Delete this explicit GODEBUG env var once Pebble is built
+      # with Go 1.13.x which defaults TLS 1.3 to on
+      GODEBUG: "tls13=1"
+    ports:
+      - 14000:14000  # HTTPS ACME API
+      - 15000:15000  # HTTPS Management API
+    environment:
+      - PEBBLE_VA_NOSLEEP=1       # No delay
+      - PEBBLE_WFE_NONCEREJECT=0  # Do not test the client's error handling
+    volumes:
+      - ./pebble/pebble-config.json:/test/config/pebble-config.json
+    networks:
+      acmenet:
+        ipv4_address: 10.30.50.2
+  challtestsrv:
+    image: letsencrypt/pebble-challtestsrv:latest
+    command: pebble-challtestsrv -defaultIPv6 "" -defaultIPv4 10.30.50.3
+    ports:
+      - 8055:8055  # HTTP Management API
+    networks:
+      acmenet:
+        ipv4_address: 10.30.50.3
+
+networks:
+  acmenet:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.30.50.0/24

--- a/devel/docker-compose.yml
+++ b/devel/docker-compose.yml
@@ -27,6 +27,15 @@ services:
     networks:
       acmenet:
         ipv4_address: 10.30.50.3
+  apt-cacher:
+    build: apt-cacher
+    ports:
+      - 3142:3142
+    volumes:
+      - apt-cache:/var/cache/apt-cacher-ng
+    networks:
+      acmenet:
+        ipv4_address: 10.30.50.4
 
 networks:
   acmenet:
@@ -35,3 +44,6 @@ networks:
       driver: default
       config:
         - subnet: 10.30.50.0/24
+
+volumes:
+  apt-cache:

--- a/devel/pebble/pebble-config.json
+++ b/devel/pebble/pebble-config.json
@@ -1,0 +1,12 @@
+{
+  "pebble": {
+    "listenAddress": "0.0.0.0:14000",
+    "managementListenAddress": "0.0.0.0:15000",
+    "certificate": "test/certs/localhost/cert.pem",
+    "privateKey": "test/certs/localhost/key.pem",
+    "httpPort": 80,
+    "tlsPort": 5001,
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": false
+  }
+}

--- a/install/playbooks/autoconfig.yml
+++ b/install/playbooks/autoconfig.yml
@@ -10,5 +10,6 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
     - autoconfig

--- a/install/playbooks/autodiscover.yml
+++ b/install/playbooks/autodiscover.yml
@@ -9,5 +9,6 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
     - autodiscover

--- a/install/playbooks/cert-imap.yml
+++ b/install/playbooks/cert-imap.yml
@@ -9,4 +9,5 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates

--- a/install/playbooks/cert-pop3.yml
+++ b/install/playbooks/cert-pop3.yml
@@ -9,4 +9,5 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates

--- a/install/playbooks/cert-smtp.yml
+++ b/install/playbooks/cert-smtp.yml
@@ -10,4 +10,5 @@
       type: smtp
       domain_alias: smtp2
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates

--- a/install/playbooks/cert-xmpp.yml
+++ b/install/playbooks/cert-xmpp.yml
@@ -9,4 +9,5 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates

--- a/install/playbooks/ejabberd.yml
+++ b/install/playbooks/ejabberd.yml
@@ -10,7 +10,8 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
 
 # When using http download, also create a specific certificate
 # to serve files over https (e.g. xmpp.homebox.space)
@@ -22,8 +23,8 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
-
+    - role: certificates
+      tags: certificates
 
 # Chat rooms behind a certificate
 - hosts: homebox
@@ -34,8 +35,8 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
-
+    - role: certificates
+      tags: certificates
 
 # Install a ejabberd (https://docs.ejabberd.im)
 - hosts: homebox

--- a/install/playbooks/extra-certs.yml
+++ b/install/playbooks/extra-certs.yml
@@ -6,4 +6,5 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - extra-certs
+    - role: extra-certs
+      tags: certificates

--- a/install/playbooks/ldap.yml
+++ b/install/playbooks/ldap.yml
@@ -15,5 +15,6 @@
     certificate:
       type: ldap
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
     - ldap

--- a/install/playbooks/main.yml
+++ b/install/playbooks/main.yml
@@ -30,7 +30,7 @@
 
 # Check if the DNS entries are now propagated on internet
 - import_playbook: dns-server-check-propagation.yml
-  when: bind.install
+  when: bind.install and bind.propagation.check
 
 # At this point, if you have installed bind,
 # perhaps you should wait a few hours until

--- a/install/playbooks/roles/certificates/meta/main.yml
+++ b/install/playbooks/roles/certificates/meta/main.yml
@@ -2,3 +2,4 @@
 
 dependencies:
   - { role: load-defaults, when: defaults_loaded is not defined }
+  - { role: external-ip-type, when: system.devel and devel.acme_server == 'pebble' }

--- a/install/playbooks/roles/certificates/tasks/gencert.yml
+++ b/install/playbooks/roles/certificates/tasks/gencert.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Open the port 80 if necessary
-  tags: security
+  tags: security, cert
   register: ufw_http
   ufw:
     proto: tcp
@@ -22,11 +22,13 @@
     {{ "-d " + domain_alias + "." + network.domain if domain_alias is defined and (domain_alias | length > 0) else "" }}
     --email "admin@{{ network.domain }}"
     {{ domain_alias_cmd is defined | ternary("--expand", "") }}
-    {{ system.devel | ternary("--test-cert", "") }}
+    {{ "" if not system.devel
+          else "--test-cert" if devel.acme_server == 'staging'
+          else "--no-verify-ssl --server https://10.30.50.2:14000/dir --force-renewal --renew-with-new-domains" }}
     --agree-tos
 
 - name: Remove the firewall rule if it has been added
-  tags: security
+  tags: security, cert
   when: ufw_http.changed
   ufw:
     proto: tcp

--- a/install/playbooks/roles/certificates/tasks/main.yml
+++ b/install/playbooks/roles/certificates/tasks/main.yml
@@ -12,7 +12,7 @@
 # especially the symbolic links in the live folder
 # The '--update' option make sure to not overwrite new certificates.
 - name: If the certificates have been generated before, copy them on the remote server
-  when: system.devel or system.keep_certs
+  when: (system.devel and devel.acme_server == 'staging') or system.keep_certs
   tags: cert,sync
   synchronize:
     src: '{{ backup_directory }}/certificates/'
@@ -118,6 +118,7 @@
     mode: '0755'
 
 - name: Check if the certificate already exists and is valid
+  tags: cert
   register: is_valid
   changed_when: false
   shell: >-
@@ -128,8 +129,16 @@
     executable: /bin/bash
   failed_when: false
 
+- name: Import Pebble tasks
+  tags: cert
+  when: system.devel and devel.acme_server == 'pebble'
+  import_tasks: pebble.yml
+# Defines generate_cert_from_pebble
+
 - name: Generate the certificate
+  tags: cert
   when: is_valid.stdout == "0"
+        or (system.devel and devel.acme_server == 'pebble' and generate_cert_from_pebble)
   include_tasks: gencert.yml
 
 # These permissions are needed to avoid problems with the
@@ -152,7 +161,7 @@
 # in case the certificates have been renewed
 # We force the permissions to 755 for dirs and 600 for files
 - name: Backup the certificates on your local machine
-  when: system.devel or system.keep_certs
+  when: (system.devel and devel.acme_server == 'staging') or system.keep_certs
   tags: cert,sync
   synchronize:
     mode: pull

--- a/install/playbooks/roles/certificates/tasks/main.yml
+++ b/install/playbooks/roles/certificates/tasks/main.yml
@@ -139,7 +139,7 @@
   tags: cert
   when: is_valid.stdout == "0"
         or (system.devel and devel.acme_server == 'pebble' and generate_cert_from_pebble)
-  include_tasks: gencert.yml
+  import_tasks: gencert.yml
 
 # These permissions are needed to avoid problems with the
 

--- a/install/playbooks/roles/certificates/tasks/pebble.yml
+++ b/install/playbooks/roles/certificates/tasks/pebble.yml
@@ -1,0 +1,67 @@
+---
+
+- name: Install the acme server root CA certificate when using pebble
+  tags: cert
+  register: root_ca_pebble
+  get_url:
+    validate_certs: no
+    url: https://10.30.50.2:15000/roots/0
+    dest: /usr/local/share/ca-certificates/pebblerootca.crt
+    force: yes
+
+- name: Make sure the DNS used by pebble resolves the external IP address by default
+  tags: cert
+  uri:
+    url: 'http://10.30.50.3:8055/set-default-ipv{{ external_ip | ipv6 | ternary("6", "4") }}'
+    method: POST
+    body: '{ "ip": "{{ external_ip }}" }'
+    body_format: json
+
+- name: Update certificates list if needed when using pebble
+  tags: cert
+  when: root_ca_pebble.changed
+  shell: /usr/sbin/update-ca-certificates -f
+
+- name: Remove former ACME accounts when the pebble CA changed
+  tags: cert
+  when: root_ca_pebble.changed
+  file:
+    path: /etc/letsencrypt/accounts/10.30.50.2:14000/
+    state: absent
+
+- name: Check the CA root certificate's start date
+  tags: cert
+  register: ca_full_startdate
+  shell: >-
+    openssl x509 -noout -startdate -in /usr/local/share/ca-certificates/pebblerootca.crt
+  changed_when: false
+
+- name: Remember the CA root certificate's start date
+  tags: cert
+  set_fact:
+    ca_startdate: "{{ ca_full_startdate.stdout[10:] | to_datetime('%b %d %H:%M:%S %Y %Z') }}"
+
+- name: Check if a certificate exists
+  tags: cert
+  stat:
+    path: /etc/letsencrypt/live/{{ certificate_fqdn }}/cert.pem
+  register: certificate_file
+
+- name: Check the certificate's start date
+  tags: cert
+  when: certificate_file.stat.exists
+  register: cert_full_startdate
+  shell: >-
+    openssl x509 -noout -startdate -in /etc/letsencrypt/live/{{ certificate_fqdn }}/cert.pem
+  changed_when: false
+
+- name: Remember the certificate's start date
+  tags: cert
+  when: certificate_file.stat.exists
+  set_fact:
+    cert_startdate: "{{ cert_full_startdate.stdout[10:] | to_datetime('%b %d %H:%M:%S %Y %Z') }}"
+
+- name: Determine if certificate must be generated
+  tags: cert
+  set_fact:
+    generate_cert_from_pebble: '{{ not certificate_file.stat.exists or cert_startdate|to_datetime < ca_startdate|to_datetime }}'

--- a/install/playbooks/roles/dovecot/tasks/main.yml
+++ b/install/playbooks/roles/dovecot/tasks/main.yml
@@ -32,6 +32,7 @@
 # At this point, the certificates should have been created already #############
 # in order to have SSL and TLS encryption activated.                           #
 - name: Set the default permissions for the imap certificate folders
+  tags: certificates
   import_role:
     name: cert-perms
   vars:
@@ -39,6 +40,7 @@
     entity_group: dovecot
 
 - name: Set the default permissions for the ldap certificate folders
+  tags: certificates
   import_role:
     name: cert-perms
   vars:
@@ -54,6 +56,7 @@
     mode: '0700'
 
 - name: Set the default permissions for the pop3 certificate folders
+  tags: certificates
   when: mail.pop3
   import_role:
     name: cert-perms

--- a/install/playbooks/roles/extra-certs/tasks/main.yml
+++ b/install/playbooks/roles/extra-certs/tasks/main.yml
@@ -3,6 +3,8 @@
 - name: Create extra certificates
   include_role:
     name: certificates
+    apply:
+      tags: certificates
   with_items:
     - '{{ extra_certs }}'
   loop_control:

--- a/install/playbooks/roles/ldap/tasks/main.yml
+++ b/install/playbooks/roles/ldap/tasks/main.yml
@@ -94,6 +94,7 @@
 # At this point, the certificates should have been created already #############
 # in order to have SSL and TLS encryption activated.                           #
 - name: Set the default permissions for the imap certificate folders
+  tags: certificates
   import_role:
     name: cert-perms
   vars:

--- a/install/playbooks/roles/mta-sts/tasks/main.yml
+++ b/install/playbooks/roles/mta-sts/tasks/main.yml
@@ -51,6 +51,7 @@
 # TLS certificate access ======================================================
 
 - name: Set permissions for www-data to the certificate folder
+  tags: certificates
   import_role:
     name: cert-perms
   vars:

--- a/install/playbooks/roles/packages/tasks/main.yml
+++ b/install/playbooks/roles/packages/tasks/main.yml
@@ -9,6 +9,20 @@
     src: sources.list
     dest: /etc/apt/sources.list
 
+- name: Use a proxy if needed
+  when: system.apt_cacher != None
+  tags: apt
+  template:
+    src: proxy
+    dest: /etc/apt/apt.conf.d/proxy
+
+- name: Make sure no proxy is configured if not needed
+  when: system.apt_cacher == None
+  tags: apt
+  file:
+    path: /etc/apt/apt.conf.d/proxy
+    state: absent
+
 # Some cloud providers, the cache_valid_time condition
 # is not working just after the installation (vultr)
 - name: Force the packages cache update on the first installation

--- a/install/playbooks/roles/packages/templates/proxy
+++ b/install/playbooks/roles/packages/templates/proxy
@@ -1,0 +1,1 @@
+Acquire::http { Proxy "http://{{ system.apt_cacher }}:3142"; }

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -12,6 +12,7 @@
 # At this point, the certificates should have been created already #############
 # in order to have SSL and TLS encryption activated.                           #
 - name: Set the default permissions for the smtp certificate folders
+  tags: certificates
   import_role:
     name: cert-perms
   vars:

--- a/install/playbooks/roundcube.yml
+++ b/install/playbooks/roundcube.yml
@@ -10,6 +10,7 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
     - imapproxy
     - roundcube

--- a/install/playbooks/rspamd-web.yml
+++ b/install/playbooks/rspamd-web.yml
@@ -10,5 +10,6 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
     - rspamd-web

--- a/install/playbooks/transmission.yml
+++ b/install/playbooks/transmission.yml
@@ -10,5 +10,6 @@
     certificate:
       type: transmission
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
     - transmission

--- a/install/playbooks/website-simple.yml
+++ b/install/playbooks/website-simple.yml
@@ -10,7 +10,8 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
 
 - hosts: homebox
   vars:
@@ -21,7 +22,8 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
 
 - hosts: homebox
   vars_files:

--- a/install/playbooks/well-known-services.yml
+++ b/install/playbooks/well-known-services.yml
@@ -12,5 +12,6 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
     - well-known-services

--- a/install/playbooks/zabbix.yml
+++ b/install/playbooks/zabbix.yml
@@ -10,6 +10,7 @@
     - '{{ playbook_dir }}/../../config/system.yml'
     - '{{ playbook_dir }}/../../config/defaults.yml'
   roles:
-    - certificates
+    - role: certificates
+      tags: certificates
     - php-fpm
     - zabbix-server

--- a/tests/playbooks/main.yml
+++ b/tests/playbooks/main.yml
@@ -19,6 +19,7 @@
 # Test opendmarc and opendkim
 - import_playbook: opendmarc.yml
 - import_playbook: opendkim.yml
+  when: bind.propagation.check
 
 # Test mail related certificates
 - import_playbook: mail-certificates.yml
@@ -86,3 +87,4 @@
 
 # Test https server quality
 - import_playbook: https-grades.yml
+  when: bind.propagation.check

--- a/tests/playbooks/roles/certificate/tasks/main.yml
+++ b/tests/playbooks/roles/certificate/tasks/main.yml
@@ -1,13 +1,23 @@
 ---
 
 - name: Install the letsencrypt staging root CA when using staging
-  register: root_ca_staging
+  when: devel.acme_server == 'staging'
+  register: root_ca
   get_url:
     url: https://letsencrypt.org/certs/fakelerootx1.pem
     dest:  /usr/local/share/ca-certificates/fakelerootx1.crt
 
+- name: Install the acme server root CA when using pebble
+  when: devel.acme_server == 'pebble'
+  register: root_ca
+  get_url:
+    validate_certs: no
+    url: https://10.30.50.2:15000/roots/0
+    dest: /usr/local/share/ca-certificates/pebblerootca.crt
+    force: yes
+
 - name: Update certificates list
-  when: root_ca_staging.changed
+  when: root_ca.changed
   shell: /usr/sbin/update-ca-certificates
 
 - name: Check if certbot is installed

--- a/tests/playbooks/roles/opendmarc/tasks/main.yml
+++ b/tests/playbooks/roles/opendmarc/tasks/main.yml
@@ -10,6 +10,7 @@
 
 - name: Test opendmarc configuration
   tags: systemctl,opendmarc
+  when: bind.propagation.check
   shell: opendmarc-check '{{ network.domain }}'
   become: yes
   become_method: sudo


### PR DESCRIPTION
Add a set of containers for:
- a local ACME server using [Pebble](https://github.com/letsencrypt/pebble) to get testing certificates without the staging Letsencrypt CA.
- an apt-cacher to speed up software updates of local virtual machines.

Also add the following options:
- `devel.acme_server`: "staging" or "pebble";
- `system.apt_cacher`: ipaddr;
- `bind.propagation.check`: boolean, to disable checks when deploying a local testing domain;

And generalize the tag "certificates" on the certificates role imports so that it can be used to fully (re-)generate all certificates when needed.

Please find more details in the commit messages.