### PR TITLE
TLS: remove ssl_protocols from nginx server confs

### DIFF
--- a/install/playbooks/roles/mta-sts/templates/nginx.conf
+++ b/install/playbooks/roles/mta-sts/templates/nginx.conf
@@ -28,7 +28,6 @@ server {
     server_tokens off;
 
     # SSL configuration
-    ssl_protocols TLSv1.1 TLSv1.2;
     ssl_certificate /etc/letsencrypt/live/mta-sts.{{ network.domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/mta-sts.{{ network.domain }}/privkey.pem;
     ssl_trusted_certificate /etc/letsencrypt/live/mta-sts.{{ network.domain }}/fullchain.pem;

--- a/install/playbooks/roles/roundcube/templates/nginx.conf
+++ b/install/playbooks/roles/roundcube/templates/nginx.conf
@@ -31,7 +31,6 @@ server {
     client_max_body_size {{ mail.max_attachment_size }}M;
 
     # SSL configuration
-    ssl_protocols TLSv1.1 TLSv1.2;
     ssl_certificate /etc/letsencrypt/live/{{ roundcube.url }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ roundcube.url }}/privkey.pem;
     ssl_trusted_certificate /etc/letsencrypt/live/{{ roundcube.url }}/fullchain.pem;

--- a/install/playbooks/roles/rspamd-web/templates/nginx.conf
+++ b/install/playbooks/roles/rspamd-web/templates/nginx.conf
@@ -30,7 +30,6 @@ server {
     server_tokens off;
 
     # SSL configuration
-    ssl_protocols TLSv1.1 TLSv1.2;
     ssl_certificate /etc/letsencrypt/live/rspamd.{{ network.domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/rspamd.{{ network.domain }}/privkey.pem;
     ssl_trusted_certificate /etc/letsencrypt/live/rspamd.{{ network.domain }}/fullchain.pem;


### PR DESCRIPTION
Some leftover from #294.

Remove the redundant and unused `ssl_protocols` nginx parameter from the
servers configurations. This parameter is defined in the global nginx
configuration (http) and takes precedence.

Modify mta-sts, roundcube and rspamd-web nginx configurations.

Could be applied on dev, but is really only a cleanup as the parameters ("TLSv1.1") are ignored.