### PR TITLE
dovecot: Search intlMailAddr for aliases in LDAP

### DIFF
--- a/install/playbooks/roles/dovecot/templates/dovecot-ldap.conf.ext
+++ b/install/playbooks/roles/dovecot/templates/dovecot-ldap.conf.ext
@@ -135,7 +135,7 @@ user_attrs = homeDirectory=home,uidNumber=uid,gidNumber=gid,mail=mail,uid=user
 #   %u - username
 #   %n - user part in user@domain, same as %u if there's no domain
 #   %d - domain part in user@domain, empty if user there's no domain
-user_filter = (&(objectClass=posixAccount)(|(uid=%n)(mail=%u)))
+user_filter = (&(objectClass=posixAccount)(|(uid=%n)(mail=%u)(intlMailAddr=%u)))
 
 # Password checking attributes:
 #  user: Virtual user name (user@domain), if you wish to change the


### PR DESCRIPTION
This change makes the aliases working on buster.

However, this configuration was not required on stretch. On buster, when the dovecot-lmtp gets the email for delivery, it considers it for the alias (eg log `dovecot: auth: Debug: master in: USER#0112#011ada.lovelace@[…]`) whereas on stretch it considers it for the already resolved user (eg `ada@`). I cannot see in the logs before dovecot-lmtp takes over where it would be different. The postfix ldap-aliases seem to do the work and resolve the alias ok.

The `check-utf8-email.yml` in tests is sending to an alias.

If you think this shouldn't be needed and can find a better fix in the integration between postfix and dovecot, it would be welcome.