### PR TITLE
Postfix submissions

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -87,6 +87,7 @@ mail_default:
       port: 465             # https://tools.ietf.org/html/rfc8314#section-3.3
     submission:             # Submission port with STARTTLS available
       port: 587
+      active: true
     # Obfuscate user agent, or complete remove
     # - version: remove the version.
     # - remove: remove the whole user agent information

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -83,7 +83,9 @@ mail_default:
   postfix:
     mynetworks: ~           # Authorized IP addresses to send emails without authentication
                             # e.g. 192.168.0.0/16, 172.16.0.0/12, 10.10.0.0/8
-    submission:
+    submissions:            # Submission port over implicit TLS
+      port: 465             # https://tools.ietf.org/html/rfc8314#section-3.3
+    submission:             # Submission port with STARTTLS available
       port: 587
     # Obfuscate user agent, or complete remove
     # - version: remove the version.

--- a/install/playbooks/roles/autoconfig/templates/config-v1.1.xml
+++ b/install/playbooks/roles/autoconfig/templates/config-v1.1.xml
@@ -26,6 +26,14 @@
     </incomingServer>
 
 {% endif %}
+    <!-- SMTP: Submission over TLS only -->
+    <outgoingServer type="smtp">
+      <hostname>smtp.{{ network.domain }}</hostname>
+      <port>{{ mail.postfix.submissions.port }}</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILLOCALPART%</username>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
     <!-- SMTP: Submission only -->
     <outgoingServer type="smtp">
       <hostname>smtp.{{ network.domain }}</hostname>

--- a/install/playbooks/roles/autoconfig/templates/config-v1.1.xml
+++ b/install/playbooks/roles/autoconfig/templates/config-v1.1.xml
@@ -34,6 +34,7 @@
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+{% if mail.postfix.submission.active %}
     <!-- SMTP: Submission only -->
     <outgoingServer type="smtp">
       <hostname>smtp.{{ network.domain }}</hostname>
@@ -42,5 +43,6 @@
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+{% endif %}
   </emailProvider>
 </clientConfig>

--- a/install/playbooks/roles/autodiscover/templates/autodiscover.xml
+++ b/install/playbooks/roles/autodiscover/templates/autodiscover.xml
@@ -35,6 +35,7 @@
     <UsePOPAuth>off</UsePOPAuth>
     <SMTPLast>on</SMTPLast>
   </Protocol>
+{% if mail.postfix.submission.active %}
   <Protocol>
     <Type>SMTP</Type>
     <Server>smtp.{{ network.domain }}</Server>
@@ -46,6 +47,7 @@
     <UsePOPAuth>off</UsePOPAuth>
     <SMTPLast>on</SMTPLast>
   </Protocol>
+{% endif %}
 {% if webmail.install %}
   <Protocol>
     <Type>WEB</Type>

--- a/install/playbooks/roles/autodiscover/templates/autodiscover.xml
+++ b/install/playbooks/roles/autodiscover/templates/autodiscover.xml
@@ -27,6 +27,17 @@
   <Protocol>
     <Type>SMTP</Type>
     <Server>smtp.{{ network.domain }}</Server>
+    <Port>{{ mail.postfix.submissions.port }}</Port>
+    <DomainRequired>off</DomainRequired>
+    <SPA>off</SPA>
+    <SSL>on</SSL>
+    <AuthRequired>on</AuthRequired>
+    <UsePOPAuth>off</UsePOPAuth>
+    <SMTPLast>on</SMTPLast>
+  </Protocol>
+  <Protocol>
+    <Type>SMTP</Type>
+    <Server>smtp.{{ network.domain }}</Server>
     <Port>{{ mail.postfix.submission.port }}</Port>
     <DomainRequired>off</DomainRequired>
     <SPA>off</SPA>

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -95,9 +95,9 @@
   with_items:
     - comment: Allow basic SMTP
       port: 25
-    - comment: Allow encrypted SMTP
-      port: 465
-    - comment: Allow submission
+    - comment: Allow submission over TLS
+      port: '{{ mail.postfix.submissions.port }}'
+    - comment: Allow submission with STARTTLS available
       port: '{{ mail.postfix.submission.port }}'
   loop_control:
     loop_var: rule
@@ -163,7 +163,7 @@
     create: yes
   with_items:
     - name: port
-      value: smtp,465,submission
+      value: smtp,submissions,submission
     - name: logpath
       value: '%(postfix_log)s'
     - name: backend

--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -87,7 +87,7 @@
 - name: Configure the firewall for default access
   tags: postfix,security
   ufw:
-    rule: allow
+    rule: '{{ rule.decision }}'
     proto: tcp
     src: any
     port: '{{ rule.port }}'
@@ -95,10 +95,13 @@
   with_items:
     - comment: Allow basic SMTP
       port: 25
+      decision: allow
     - comment: Allow submission over TLS
       port: '{{ mail.postfix.submissions.port }}'
-    - comment: Allow submission with STARTTLS available
+      decision: allow
+    - comment: '{{ mail.postfix.submission.active | ternary("Allow", "Deny") }} submission with STARTTLS available'
       port: '{{ mail.postfix.submission.port }}'
+      decision: '{{ mail.postfix.submission.active | ternary("allow", "deny") }}'
   loop_control:
     loop_var: rule
 

--- a/install/playbooks/roles/postfix/templates/30-postfix.bind
+++ b/install/playbooks/roles/postfix/templates/30-postfix.bind
@@ -11,9 +11,13 @@ smtp2   IN       {{ "%-4s" | format(backup_ip_type) }}    {{ backup_ip }}
 {% endif %}
 
 ;; RFC 6186 entries, should point to a proper A/AAAA record
-_submission._tcp 3600 IN SRV 0 0 {{ mail.postfix.submission.port }} smtp.{{ network.domain }}.
+_submissions._tcp 3600 IN SRV 0 0 {{ mail.postfix.submissions.port }} smtp.{{ network.domain }}.
 {% if backup_ip is defined and backup_ip != "" %}
-_submission._tcp 3600 IN SRV 0 0 {{ mail.postfix.submission.port }} smtp2.{{ network.domain }}.
+_submissions._tcp 3600 IN SRV 10 0 {{ mail.postfix.submissions.port }} smtp2.{{ network.domain }}.
+{% endif %}
+_submission._tcp 3600 IN SRV 20 0 {{ mail.postfix.submission.port }} smtp.{{ network.domain }}.
+{% if backup_ip is defined and backup_ip != "" %}
+_submission._tcp 3600 IN SRV 30 0 {{ mail.postfix.submission.port }} smtp2.{{ network.domain }}.
 {% endif %}
 
 ;; SPF record

--- a/install/playbooks/roles/postfix/templates/30-postfix.bind
+++ b/install/playbooks/roles/postfix/templates/30-postfix.bind
@@ -15,9 +15,11 @@ _submissions._tcp 3600 IN SRV 0 0 {{ mail.postfix.submissions.port }} smtp.{{ ne
 {% if backup_ip is defined and backup_ip != "" %}
 _submissions._tcp 3600 IN SRV 10 0 {{ mail.postfix.submissions.port }} smtp2.{{ network.domain }}.
 {% endif %}
+{% if mail.postfix.submission.active %}
 _submission._tcp 3600 IN SRV 20 0 {{ mail.postfix.submission.port }} smtp.{{ network.domain }}.
 {% if backup_ip is defined and backup_ip != "" %}
 _submission._tcp 3600 IN SRV 30 0 {{ mail.postfix.submission.port }} smtp2.{{ network.domain }}.
+{% endif %}
 {% endif %}
 
 ;; SPF record

--- a/install/playbooks/roles/postfix/templates/fail2ban-noise-reduction.conf
+++ b/install/playbooks/roles/postfix/templates/fail2ban-noise-reduction.conf
@@ -5,7 +5,7 @@
 before = common.conf
 
 [Definition]
-_daemon = postfix(-\w+)?/(?:submission/|smtps/)?smtp[ds]
+_daemon = postfix(-\w+)?/(?:submission/|smtps/|submissions/)?smtp[ds]
 failregex = ^%(__prefix_line)swarning: hostname [^\s]+ does not resolve to address <HOST>$
 ignoreregex =
 enabled = True

--- a/install/playbooks/roles/postfix/templates/master.cf
+++ b/install/playbooks/roles/postfix/templates/master.cf
@@ -16,16 +16,16 @@ smtp      inet  n       -       y       -       -       smtpd
 #tlsproxy  unix  -       -       y       -       0       tlsproxy
 subcleanup unix  n       -       -       -       0       cleanup
     -o header_checks=pcre:/etc/postfix/headers-check.cf
+submissions inet n       -       y       -       -       smtpd
+  -o syslog_name=postfix/submissions
+  -o cleanup_service_name=subcleanup
+  -o smtpd_discard_ehlo_keywords=silent-discard,etrn
+  -o smtpd_tls_wrappermode=yes
+  -o smtpd_relay_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
 submission inet n       -       y       -       -       smtpd
   -o syslog_name=postfix/submission
   -o cleanup_service_name=subcleanup
   -o smtpd_discard_ehlo_keywords=silent-discard,etrn
-  -o smtpd_relay_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
-smtps     inet  n       -       y       -       -       smtpd
-  -o syslog_name=postfix/smtps
-  -o cleanup_service_name=subcleanup
-  -o smtpd_discard_ehlo_keywords=silent-discard,etrn
-  -o smtpd_tls_wrappermode=yes
   -o smtpd_relay_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
 #628       inet  n       -       y       -       -       qmqpd
 pickup    unix  n       -       y       60      1       pickup

--- a/install/playbooks/roles/postfix/templates/master.cf
+++ b/install/playbooks/roles/postfix/templates/master.cf
@@ -22,11 +22,13 @@ submissions inet n       -       y       -       -       smtpd
   -o smtpd_discard_ehlo_keywords=silent-discard,etrn
   -o smtpd_tls_wrappermode=yes
   -o smtpd_relay_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
+{% if mail.postfix.submission.active %}
 submission inet n       -       y       -       -       smtpd
   -o syslog_name=postfix/submission
   -o cleanup_service_name=subcleanup
   -o smtpd_discard_ehlo_keywords=silent-discard,etrn
   -o smtpd_relay_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
+{% endif %}
 #628       inet  n       -       y       -       -       qmqpd
 pickup    unix  n       -       y       60      1       pickup
 cleanup   unix  n       -       y       -       0       cleanup

--- a/tests/playbooks/dns-records-email-submission.yml
+++ b/tests/playbooks/dns-records-email-submission.yml
@@ -1,0 +1,12 @@
+---
+
+# Test the DNS server for service records
+- hosts: homebox
+  vars:
+    records:
+      type: SRV
+      list:
+        - name: '_submission._tcp.{{ network.domain }}'
+          value: 'smtp\.{{ network.domain }}'
+  roles:
+    - dns-records

--- a/tests/playbooks/dns-records-email.yml
+++ b/tests/playbooks/dns-records-email.yml
@@ -43,8 +43,6 @@
           value: 'imap\.{{ network.domain }}'
         - name: '_submissions._tcp.{{ network.domain }}'
           value: 'smtp\.{{ network.domain }}'
-        - name: '_submission._tcp.{{ network.domain }}'
-          value: 'smtp\.{{ network.domain }}'
   roles:
     - dns-records
 

--- a/tests/playbooks/dns-records-email.yml
+++ b/tests/playbooks/dns-records-email.yml
@@ -41,6 +41,8 @@
           value: '0 0 0 \.'
         - name: '_imaps._tcp.{{ network.domain }}'
           value: 'imap\.{{ network.domain }}'
+        - name: '_submissions._tcp.{{ network.domain }}'
+          value: 'smtp\.{{ network.domain }}'
         - name: '_submission._tcp.{{ network.domain }}'
           value: 'smtp\.{{ network.domain }}'
   roles:

--- a/tests/playbooks/main.yml
+++ b/tests/playbooks/main.yml
@@ -54,6 +54,10 @@
 - import_playbook: dns-records-email-pop3.yml
   when: bind.install and mail.pop3
 
+# Test submission specific DNS records
+- import_playbook: dns-records-email-submission.yml
+  when: mail.postfix.submission.active
+
 # Test Jabber client to client functions
 - import_playbook: dns-records-jabber-c2s.yml
   when: bind.install and ejabberd.install

--- a/tests/playbooks/roles/postfix/tasks/check-certificates.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-certificates.yml
@@ -4,13 +4,13 @@
   tags: systemctl,postfix
   shell: postfix status
 
-- name: Check the certificate using SMTPS
+- name: Check the certificate using SMTP over TLS on submissions port
   tags: systemctl, postfix
   shell: >-
     set -o pipefail ;
     echo QUIT | openssl s_client
     -servername smtp.{{ network.domain }}
-    -connect smtp.{{ network.domain }}:465 2>&1
+    -connect smtp.{{ network.domain }}:{{ mail.postfix.submissions.port }} 2>&1
     | grep 'Verification: OK'
   args:
     executable: /bin/bash
@@ -27,13 +27,13 @@
   args:
     executable: /bin/bash
 
-- name: Check the certificate using SMTP and STARTTLS On submission port
+- name: Check the certificate using SMTP and STARTTLS on submission port
   tags: systemctl, postfix
   shell: >-
     set -o pipefail ;
     echo QUIT | openssl s_client
     -servername smtp.{{ network.domain }}
-    -connect smtp.{{ network.domain }}:587
+    -connect smtp.{{ network.domain }}:{{ mail.postfix.submission.port }}
     -starttls smtp 2>&1
     | grep 'Verification: OK'
   args:

--- a/tests/playbooks/roles/postfix/tasks/check-certificates.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-certificates.yml
@@ -29,6 +29,7 @@
 
 - name: Check the certificate using SMTP and STARTTLS on submission port
   tags: systemctl, postfix
+  when: mail.postfix.submission.active
   shell: >-
     set -o pipefail ;
     echo QUIT | openssl s_client


### PR DESCRIPTION
This is about the submission port over TLS (465) now called the "submissions" service as defined and updated in RFC8314, recommending TLS over STARTTLS.

Please see the commit messages for more details.
