### PR TITLE
Git hooks: treating warnings as error

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # From .git/hooks/pre-commit.sample
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then
@@ -11,7 +13,7 @@ fi
 
 # If there are whitespace errors or leftover merge conflicts markers,
 # print the offending file names and fail.
-git diff-index --check --cached "$against" -- || exit $?
+git diff-index --check --cached "$against" --
 
 # Create a temporary file to list ansible files to check
 tmp_checklist=$(mktemp)
@@ -34,49 +36,77 @@ git diff-index --cached --name-only --diff-filter=ACMR -z "$against" -- \
 # If the checklist file is not empty, run ansible-lint
 if [ -s "$tmp_checklist" ]
 then
+	# Check if ansible is usable
+	ansible-lint --version >/dev/null || {
+		cat >&2 <<- EOF
+
+		Please make sure ansible-lint is installed and usable.
+
+		The git pre-push hook uses ansible-lint to validate ansible playbooks YAML
+		files on commits.
+
+		EOF
+		exit 1
+	}
 	echo "Let's check files with ansible-lint"
 
 	# Create a temporary directory
-	tmp_dir="$(mktemp -d)/"
+	tmp_dir="$(mktemp -d)"
+
+	# Set the log file
+	log_file="$(git rev-parse --show-toplevel)/logs/ansible-lint-pre-commit.log"
 
 	# Checkout all the files in the index to the temporary directory
 	echo "Checking out all files in the index to $tmp_dir"
-	git checkout-index --prefix="$tmp_dir" -a
+	git checkout-index --prefix="$tmp_dir/" -a
 
-	# Run ansible-lint in the temporary directory on the ansible YAML files
-	# to be committed and remember the return value of the xargs call
-	( cd "$tmp_dir" \
-		&& xargs -0 ansible-lint < "$tmp_checklist" ) ; lint_result=$?
+	# Use a subshell to get to the temporary directory, run ansible-lint
+	# with a different error handling, and remember the exit status of the
+	# xargs call if any error
+	lint_result=0
+	(
+		cd "$tmp_dir"
+
+		# Do not exit on error until the end of the subshell
+		set +e
+
+		echo "Running ansible-lint on modified ansible files"
+		echo "Full log is being written to $log_file"
+		# shellcheck disable=SC2016
+		xargs -0 -I{} \
+			sh -c 'PYTHONUNBUFFERED=1 ansible-lint "$1" 2>&1' -- "{}" \
+			< "$tmp_checklist" \
+			> "$log_file" 2>&1
+
+	# Back to: set -e
+	) || lint_result=$?
 
 	# Remove the temporary directory
 	rm -rf "$tmp_dir"
 
+	# Remove the temporary checklist file
+	rm -f "$tmp_checklist"
+
 	case "$lint_result" in
 		"0")
-			echo "Please beware of any warning"
+			if grep --color=auto -h -e 'WARNING:' "$log_file" >&2
+			then
+				echo "Please address the ansible-lint warnings"
+				exit 1
+			fi
 			echo "Looks good for ansible-lint"
 			;;
 		"123")
-			echo "Please fix the ansible-lint errors"
-			;;
-		"126"|"127") # ansible-lint cannot be run or is not found
-			cat << EOF
-
-Please make sure ansible-lint is installed and usable.
-
-The git pre-commit hook uses ansible-lint to validate YAML ansible playbooks
-files on commits.
-
-EOF
+			grep --color=auto -h -A 11 -e 'Syntax Error' "$log_file" >&2 || true
+			grep --color=auto -h -e '\[E...]' "$log_file" >&2 || true
+			grep --color=auto -h -e 'WARNING:' "$log_file" >&2 || true
+			echo "Please fix the ansible-lint errors and warnings"
 			;;
 		*)
-			echo "Sorry, something wrong happened"
+			echo >&2 "Sorry, something wrong happened"
 			;;
 	esac
 fi
-
-# Remove the temporary checklist file
-rm -f "$tmp_checklist"
 
 # Fail in case of error
 exit ${lint_result:-0}

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/sh
+
+set -e
 
 # From .git/hooks/pre-push.sample
 # Not used for now
@@ -6,11 +8,21 @@
 # url="$2"
 z40=0000000000000000000000000000000000000000
 
+# Check if ansible is usable
+ansible-lint --version >/dev/null || {
+	cat >&2 <<- EOF
+
+	Please make sure ansible-lint is installed and usable.
+
+	The git pre-push hook uses ansible-lint to validate ansible playbooks YAML
+	files on commits.
+
+	EOF
+	exit 1
+}
+
 # Create the logs directory if not exists. It is ignored by git anyway
 test -d logs || mkdir logs
-
-# Manage errors in pipelines
-set -o pipefail
 
 while read -r local_ref local_sha _ _ # remote_ref and remote_sha are not used
 do
@@ -21,70 +33,76 @@ do
 		:
 		# Continue processing the next branch if any
 	else
-		# Create a temporary directory
-		tmp_dir="$(mktemp -d)/"
+		echo "Let's check files with ansible-lint"
 
-		# Remember the main working tree toplevel
-		main_working_tree_dir="$(git rev-parse --show-toplevel)"
+		# Create a temporary file to list ansible files to check
+		tmp_checklist=$(mktemp)
+
+		# Write the list of the main ansible files and directories
+		find \
+			common/roles/* \
+			install/playbooks/main.yml \
+			tests/playbooks/main.yml \
+			uninstall/playbooks/*.yml \
+			-maxdepth 0 -print0 \
+			> "$tmp_checklist"
+
+		# Create a temporary directory
+		tmp_dir="$(mktemp -d)"
+
+		# Set the log file
+		log_file="$(git rev-parse --show-toplevel)/logs/ansible-lint-pre-push.log"
 
 		# Export the branch to the temporary directory
 		echo "Exporting $local_ref to $tmp_dir"
 		git archive "$local_sha" | tar -x -C "$tmp_dir" || exit $?
 
-		# Run ansible-lint in the temporary directory on the main
-		# ansible files and directories and exit from the subshell on
-		# error
+		# Use a subshell to get to the temporary directory, run ansible-lint
+		# with a different error handling, and remember the exit status of the
+		# xargs call if any error
+		lint_result=0
 		(
-			cd "$tmp_dir" || exit 2 # Not an ansible-lint error
+			cd "$tmp_dir"
 
-			# Run ansible lint on the common roles
-			ansible-lint common/roles/* 2>&1 \
-				| tee "$main_working_tree_dir"/logs/ansible-lint-common.log \
-				|| exit $?
+			# Do not exit on error until the end of the subshell
+			set +e
 
-			# Run ansible lint on the installation playbooks
-			ansible-lint install/playbooks/main.yml 2>&1 \
-				| tee "$main_working_tree_dir"/logs/ansible-lint-install.log \
-				|| exit $?
+			echo "Running ansible-lint on all playbooks"
+			echo "Full log is being written to $log_file"
+			# shellcheck disable=SC2016
+			xargs -0 -I {} \
+				sh -c 'PYTHONUNBUFFERED=1 ansible-lint "$1" 2>&1' -- "{}" \
+				< "$tmp_checklist" \
+				> "$log_file"
 
-			# Run ansible lint on the test playbooks
-			ansible-lint tests/playbooks/main.yml 2>&1 \
-				| tee "$main_working_tree_dir"/logs/ansible-lint-tests.log \
-				|| exit $?
-
-			# Run ansible lint on the uninstall playbooks
-			ansible-lint uninstall/playbooks/*.yml 2>&1 \
-				| tee "$main_working_tree_dir"/logs/ansible-lint-uninstall.log \
-				|| exit $?
-
-		) ; lint_result=$?
+		# Back to: set -e
+		) || lint_result=$?
 
 		# Remove the temporary directory
 		rm -rf "$tmp_dir"
 
+		# Remove the temporary checklist file
+		rm -f "$tmp_checklist"
+
 		case "$lint_result" in
 			"0")
-				echo "Please beware of any warning"
+				if grep --color=auto -h -e 'WARNING:' "$log_file" >&2
+				then
+					echo "Please address the ansible-lint warnings"
+					exit 1
+				fi
 				echo "Looks good for ansible-lint"
 				# Continue processing the next branch if any
 				;;
-			"1")
-				echo "Please fix the ansible-lint errors"
-				exit $lint_result
-				;;
-			"126"|"127") # ansible-lint cannot be run or is not found
-				cat <<- EOF
-
-				Please make sure ansible-lint is installed and usable.
-
-				The git pre-push hook uses ansible-lint to validate YAML ansible playbooks
-				files on commits.
-
-				EOF
+			"123")
+				grep --color=auto -h -A 11 -e 'Syntax Error' "$log_file" >&2 || true
+				grep --color=auto -h -e '\[E...]' "$log_file" >&2 || true
+				grep --color=auto -h -e 'WARNING:' "$log_file" >&2 || true
+				echo "Please fix the ansible-lint errors and warnings"
 				exit $lint_result
 				;;
 			*)
-				echo "Sorry, something wrong happened"
+				echo >&2 "Sorry, something wrong happened"
 				exit $lint_result
 				;;
 		esac


### PR DESCRIPTION
The second step for the hooks. Should help catch imports or includes of missing ansible files.

Please find some more details in the commit messages.