### PR TITLE
Ensure service submission<s> is known by the system

### DIFF
--- a/install/playbooks/roles/postfix/tasks/main.yml
+++ b/install/playbooks/roles/postfix/tasks/main.yml
@@ -74,6 +74,13 @@
   loop_control:
     loop_var: file
 
+# Debian Stretch, the port 465 is not named submission<s>
+- name: Ensure submission<s> is in the services list
+  replace:
+    path: /etc/services
+    regexp: '(urd\s+465/tcp\s+ssmtp smtps)(\s+)(#.*)'
+    replace: '\1 submissions\2\3'
+
 - name: Refresh the senders bcc map
   tags: postfix
   notify: Restart postfix


### PR DESCRIPTION
This fix need to be applied on Debian Stretch as the service is
unknown and postfix fails to start