### PR TITLE
Ansible tuning

### DIFF
--- a/common/ansible.cfg
+++ b/common/ansible.cfg
@@ -6,6 +6,8 @@ callback_whitelist = profile_roles
 roles_path = .:{{ playbook_dir }}/../../common/roles/
 connection_plugins = {{ playbook_dir }}/../../common/connection-plugins/
 remote_tmp = /tmp/
+gathering=smart
+gather_subset=!all,!min,hardware,network
 [ssh_connection]
 pipelining = True
 ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o PreferredAuthentications=publickey

--- a/common/ansible.cfg
+++ b/common/ansible.cfg
@@ -6,3 +6,6 @@ callback_whitelist = profile_roles
 roles_path = .:{{ playbook_dir }}/../../common/roles/
 connection_plugins = {{ playbook_dir }}/../../common/connection-plugins/
 remote_tmp = /tmp/
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o PreferredAuthentications=publickey

--- a/tests/playbooks/roles/postfix/tasks/check-extension-email.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-extension-email.yml
@@ -3,7 +3,7 @@
 - name: Create a unique subject for testing
   tags: postfix
   set_fact:
-    test_subject: 'Test email {{ ansible_date_time.iso8601_micro | to_uuid }}'
+    test_subject: "Test email {{ lookup( 'password', '/dev/null length=32' ) | to_uuid }}"
 
 - name: Create an email template
   tags: postfix

--- a/tests/playbooks/roles/postfix/tasks/check-simple-email.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-simple-email.yml
@@ -3,7 +3,7 @@
 - name: Create a unique subject for testing
   tags: postfix
   set_fact:
-    test_subject: 'Test email {{ ansible_date_time.iso8601_micro | to_uuid }}'
+    test_subject: "Test email {{ lookup( 'password', '/dev/null length=32' ) | to_uuid }}"
 
 - name: Create an email template
   tags: postfix

--- a/tests/playbooks/roles/postfix/tasks/check-utf8-email.yml
+++ b/tests/playbooks/roles/postfix/tasks/check-utf8-email.yml
@@ -3,7 +3,7 @@
 - name: Create a unique subject for testing
   tags: postfix
   set_fact:
-    test_subject: 'Test email {{ ansible_date_time.iso8601_micro | to_uuid }}'
+    test_subject: "Test email {{ lookup( 'password', '/dev/null length=32' ) | to_uuid }}"
 
 - name: Create an email template
   tags: postfix


### PR DESCRIPTION
Tune some ansible parameters to try to execute faster, mainly:

- SSH pipelining: disabled by default in ansible because in conflict with sudoers configurations using the `requiretty` option, which is not the case in Debian by default ;

- Smart fact gathering policy, which uses the ansible cache plugin and so requires to change the generation of unique email subjects in the tests playbooks (and was quite something to debug).

Please find more details in the commit messages.

A bit more than 20% faster on the re-execution of the main install playbook of an already deployed server (so nothing much done, just connections to the server to check), the server being a VM on the same machine, so without any network latency.
