### PR TITLE
Cert perms

### DIFF
--- a/install/roles/dovecot/tasks/main.yml
+++ b/install/roles/dovecot/tasks/main.yml
@@ -39,6 +39,15 @@
     cert_dir: 'imap.{{ network.domain }}'
     entity_group: dovecot
 
+- name: Set the default permissions for the ldap certificate folders
+  tags: certificates
+  import_role:
+    name: cert-perms
+  vars:
+    cert_dir: 'ldap.{{ network.domain }}'
+    entity_group: dovecot
+    access_private_key: false
+
 - name: Copy the certificate renewal hook
   tags: scripts
   copy:

--- a/install/roles/mta-sts/tasks/main.yml
+++ b/install/roles/mta-sts/tasks/main.yml
@@ -49,16 +49,6 @@
     src: 35-mta-sts.bind
     dest: /etc/homebox/dns-entries.d/35-mta-sts.bind
 
-# TLS certificate access ======================================================
-
-- name: Set permissions for www-data to the certificate folder
-  tags: certificates
-  import_role:
-    name: cert-perms
-  vars:
-    cert_dir: 'mta-sts.{{ network.domain }}'
-    entity_group: 'www-data'
-
 # AppArmor configuration ======================================================
 
 - name: Install nginx AppArmor profile

--- a/install/roles/postfix/tasks/main.yml
+++ b/install/roles/postfix/tasks/main.yml
@@ -8,17 +8,9 @@
     name: "{{ postfix_pkgs }}"
     state: present
 
-################################################################################
-# At this point, the certificates should have been created already #############
-# in order to have SSL and TLS encryption activated.                           #
-- name: Set the default permissions for the smtp certificate folders
-  tags: certificates
-  import_role:
-    name: cert-perms
-  vars:
-    cert_dir: 'smtp.{{ network.domain }}'
-    entity_group: postfix
-
+#################################################################################
+## At this point, the certificates should have been created already #############
+## in order to have SSL and TLS encryption activated.                           #
 - name: Copy the certificate renewal hook
   tags: cert
   copy:


### PR DESCRIPTION
Dovecot apparently still needs to access the LDAP fullchain certificates (not the private key) even in buster, due to its (open)ldap client configuration.

There was a `www-data` access remaining in mta-sts, and the user postfix doesn't seem to need access to the certificates or private key.

This is not everything, since there is still the issue with openldap. The ldap role (and the calls to cert-perms) seems to do what's needed, but running the main playbook the mask of the private key seems to be reset at some point (to 0, giving an `effective: ---` for the user openldap).