### PR TITLE
nginx: Use return 301 to redirect requests

### DIFF
--- a/install/roles/certificates-all/templates/nginx-cert.conf
+++ b/install/roles/certificates-all/templates/nginx-cert.conf
@@ -26,7 +26,7 @@ server {
 {% if redirect_to_https == true %}
     location / {
         # redirect inital requests to https
-        rewrite ^ https://$server_name$request_uri? permanent;
+        return 301 https://$server_name$request_uri;
     }
 {% else %}
     # Do not use a favicon


### PR DESCRIPTION
It is documented as the preferred way of doing it:
https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#taxing-rewrites