### PR TITLE
well-known-services: serve well-known dir on HTTPS

### DIFF
--- a/install/roles/well-known-services/templates/nginx.conf
+++ b/install/roles/well-known-services/templates/nginx.conf
@@ -43,6 +43,10 @@ server {
     }
 {% endif %}
 
+    location /.well-known/ {
+        # make sure well-known files are served for {{ network.domain }}
+    }
+
 {% if website.install %}
     # Default web site: redirect to www.{{ network.domain }}
     location / {


### PR DESCRIPTION
Add a location for the `/.well-known/` URL prefix to serve the directory
for the base `{{ network.domain }}` on HTTPS.