### PR TITLE
Add an OpenPGP Web Key Directory role

### DIFF
--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -164,3 +164,33 @@ mail:
   #   - 'ip6:fe80::2e0:70ff:fe63:f069/64'
   #   - 'include:_spf.google.com'
 ```
+
+## OpenPGP Web Key Directory
+
+You can publish your users' PGP public keys as a [Web Key
+Directory](https://tools.ietf.org/html/draft-koch-openpgp-webkey-service).
+
+Mail clients should locate PGP public keys automatically using this scheme, as
+well as [GnuPG doing it by default since version
+2.1.23](https://wiki.gnupg.org/WKD#Implementations).
+
+The public keys are published according to both the direct and advanced
+methods: the advanced method is recommended; the direct method might be needed
+to support the first clients that implemented the RFC draft.
+
+To deploy the Web Key Directory, the public keys are expected to be in the
+server configuration in a "pgp" object list along with the user's uid.
+
+```
+pgp:
+  - uid: marie
+    ascii_armored_public_key: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+      […]
+      -----END PGP PUBLIC KEY BLOCK-----
+```
+
+This `pgp` list is separate from the `users` list to be able to put it at the
+end of the configuration file, the PGP public keys being a bit larger than SSH
+public keys.

--- a/install/main.yml
+++ b/install/main.yml
@@ -62,6 +62,8 @@
             create: '{{ transmission.install }}'
           - type: zabbix
             create: '{{ zabbix.install }}'
+          - type: openpgpkey
+            create: '{{ pgp is defined }}'
       tags: cert
     - role: ldap
       tags: ldap
@@ -150,6 +152,9 @@
       tags: cert, extra-certs
     - role: well-known-services
       tags: nginx
+    - role: openpgp-wkd
+      when: pgp is defined
+      tags: openpgp-wkd
     - role: system-post-install
       tags: always
 

--- a/install/roles/openpgp-wkd/handlers/main.yml
+++ b/install/roles/openpgp-wkd/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Activate AppArmor profile
+  command: 'aa-enforce usr.sbin.nginx'
+
+- name: Restart AppArmor service
+  service:
+    name: apparmor
+    state: restarted
+
+- name: Restart nginx
+  service:
+    name: nginx
+    state: restarted

--- a/install/roles/openpgp-wkd/tasks/create_wkd_files.yml
+++ b/install/roles/openpgp-wkd/tasks/create_wkd_files.yml
@@ -1,0 +1,29 @@
+---
+
+# Expects :
+# - `well_known_dir`: base directory for the `hu` directory and `policy` file
+# - `public_keys`: the list of public keys with ascii armor with corresponding
+#                  uid and wkd_hash
+
+- name: Create the directories for the openpgp keys
+  file:
+    path: '{{ well_known_dir }}/hu'
+    state: directory
+
+- name: Create an empty policy file as required
+  file:
+    path: '{{ well_known_dir }}/policy'
+    state: touch
+    modification_time: preserve
+    access_time: preserve
+
+- name: Loop over wkd hashes for the direct method
+  vars:
+    filename: "{{ well_known_dir }}/hu/{{ item.wkd_hash }}"
+  command:
+    cmd: gpg --no-keyring --no-options --import --import-options import-export --output "{{ filename }}"
+    stdin: '{{ item.ascii_armored_public_key }}'
+    creates: "{{ filename }}"
+  loop: "{{ public_keys }}"
+  loop_control:
+    label: "{{ item.uid }}"

--- a/install/roles/openpgp-wkd/tasks/main.yml
+++ b/install/roles/openpgp-wkd/tasks/main.yml
@@ -1,0 +1,98 @@
+---
+
+- name: Register PGP public keys details
+  command:
+    cmd: gpg --no-keyring --no-options --show-keys --with-wkd-hash
+    stdin: '{{ item.ascii_armored_public_key }}'
+  register: pgp_details
+  loop: "{{ pgp | list }}"
+  loop_control:
+    label: "{{ item.uid }}"
+
+- name: Register usable PGP public keys information
+  set_fact:
+    pgp_public_keys: >-
+      {{ pgp_public_keys
+        | default([])
+        | union([
+          {
+            'uid': item.item.uid,
+            'wkd_hash': item.stdout | regex_search('(?<!<)([0-9a-z]{32})(?=@)',
+                                                    Multiline=True),
+            'ascii_armored_public_key': item.item.ascii_armored_public_key
+          }
+        ])
+      }}
+  with_items: "{{ pgp_details.results | select('succeeded') | list }}"
+
+- name: Publish the files for the advanced method
+  vars:
+    public_keys: "{{ pgp_public_keys }}"
+    well_known_dir: '/var/www/openpgpkey/.well-known/openpgpkey/{{ network.domain }}'
+  import_tasks: create_wkd_files.yml
+
+- name: Publish the files for the direct method
+  vars:
+    public_keys: "{{ pgp_public_keys }}"
+    well_known_dir:  '/var/www/default/.well-known/openpgpkey'
+  import_tasks: create_wkd_files.yml
+
+- name: Create the nginx template
+  tags: nginx
+  notify: Restart nginx
+  vars:
+    csp: '{{ csp_default }}'
+    fp: '{{ fp_default }}'
+  template:
+    src: nginx.conf
+    dest: '/etc/nginx/sites-available/openpgpkey.{{ network.domain }}.conf'
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Activate openpgpkey web site
+  tags: nginx
+  notify: Restart nginx
+  file:
+    src: '/etc/nginx/sites-available/openpgpkey.{{ network.domain }}.conf'
+    dest: '/etc/nginx/sites-enabled/openpgpkey.{{ network.domain }}.conf'
+    state: link
+
+- name: Add the openpgpkey DNS sub-domain to bind
+  tags: bind
+  when: bind.install
+  template:
+    src: 80-openpgpkey.bind
+    dest: /etc/homebox/dns-entries.d/80-openpgpkey.bind
+
+# AppArmor configuration ======================================================
+
+- name: Install nginx AppArmor profile
+  notify:
+    - Activate AppArmor profile
+    - Restart AppArmor service
+    - Restart nginx
+  tags: security, apparmor
+  template:
+    src: apparmor.d/local/openpgpkey
+    dest: /etc/apparmor.d/local/openpgpkey
+
+- name: Check if AppArmor nginx configuration already contains the line
+  register: line_found
+  shell: >-
+    grep -c 'include <local/openpgpkey>'
+    /etc/apparmor.d/usr.sbin.nginx
+  changed_when: false
+  failed_when: false
+
+- name: Add AppArmor specific configuration
+  when: line_found.stdout == '0'
+  notify:
+    - Activate AppArmor profile
+    - Restart AppArmor service
+    - Restart nginx
+  tags: security, apparmor
+  lineinfile:
+    path: /etc/apparmor.d/usr.sbin.nginx
+    line: '  #include <local/openpgpkey>'
+    insertbefore: '# End of local includes for homebox'

--- a/install/roles/openpgp-wkd/templates/80-openpgpkey.bind
+++ b/install/roles/openpgp-wkd/templates/80-openpgpkey.bind
@@ -1,0 +1,2 @@
+;; OpenPGP Web Key Directory advanced method sub-domain
+openpgpkey  IN       CNAME      main

--- a/install/roles/openpgp-wkd/templates/apparmor.d/local/openpgpkey
+++ b/install/roles/openpgp-wkd/templates/apparmor.d/local/openpgpkey
@@ -1,0 +1,10 @@
+  # Certificates
+  /etc/letsencrypt/archive/openpgpkey.{{ network.domain }}/* r,
+  /etc/letsencrypt/live/openpgpkey.{{ network.domain }}/* r,
+
+  # Certificate renewal and text file content
+  /var/www/openpgpkey/.well-known/** r,
+
+  # Log files
+  /var/log/nginx/openpgpkey-access.log w,
+  /var/log/nginx/openpgpkey-error.log w,

--- a/install/roles/openpgp-wkd/templates/nginx.conf
+++ b/install/roles/openpgp-wkd/templates/nginx.conf
@@ -1,0 +1,56 @@
+
+# Default server configuration
+#
+server {
+
+    # Lisent on IPv4 and IPv6
+    listen 443 ssl http2;
+    listen [::]:443 ssl;
+
+    # Add security headers
+    {% for sh in nginx_sec_headers -%}
+    add_header {{ sh.id }} {{ sh.value | quote }};
+    {% endfor %}
+
+    # Add Content security policy
+    add_header Content-Security-Policy "{%- for c in csp.list %}{{ c.id }} {{ c.value | default(csp.default) }};{% endfor %}";
+
+    # Features policy
+    add_header Feature-Policy "{%- for f in fp.list %}{{ f.id }} {{ f.value | default(fp.default) }};{% endfor %}";
+
+    # web site FQDN
+    server_name openpgpkey.{{ network.domain }};
+
+    # Almost empty site root
+    root /var/www/openpgpkey/;
+
+    # Remove useless tokens for better security feelings ;-)
+    server_tokens off;
+
+    # SSL configuration
+    ssl_certificate /etc/letsencrypt/live/openpgpkey.{{ network.domain }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/openpgpkey.{{ network.domain }}/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/openpgpkey.{{ network.domain }}/fullchain.pem;
+
+    # Add index.php to the list if you are using PHP
+    index index.html;
+
+    # log files per virtual host
+    access_log /var/log/nginx/openpgpkey-access.log;
+    error_log /var/log/nginx/openpgpkey-error.log;
+
+    # Do not use a favicon
+    location ~ ^/favicon.ico$ {
+        root /var/www/default/;
+        log_not_found off;
+        access_log off;
+        expires max;
+    }
+
+    # Nothing here
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+}

--- a/install/roles/openpgp-wkd/vars/main.yml
+++ b/install/roles/openpgp-wkd/vars/main.yml
@@ -1,0 +1,49 @@
+---
+
+# Default nginx security headers for the simple web site.
+# You can override this
+nginx_sec_headers:
+  - id: Strict-Transport-Security
+    value: max-age=31536000
+  - id: X-Content-Type-Options
+    value: nosniff
+  - id: Referrer-Policy
+    value: same-origin
+  - id: X-Frame-Options
+    value: sameorigin
+
+####
+csp_default:
+  default: "'none'"
+  list:
+    - id: default-src
+    - id: script-src
+    - id: img-src
+    - id: style-src
+    - id: media-src
+    - id: font-src
+    - id: base-uri
+    - id: frame-src
+    - id: object-src
+    - id: connect-src
+
+
+### Features policy
+# See https://github.com/w3c/webappsec-feature-policy
+# Set to 'none' by default
+fp_default:
+  default: "'none'"
+  list:
+    - id: geolocation
+    - id: midi
+    - id: notifications
+    - id: push
+    - id: sync-xhr
+    - id: microphone
+    - id: camera
+    - id: magnetometer
+    - id: gyroscope
+    - id: speaker
+    - id: vibrate
+    - id: fullscreen
+    - id: payment


### PR DESCRIPTION
This PR requires #355 first, and addresses #336.

Use both the direct and advanced publishing methods.

- The direct method uses the well-known directory of the base domain.
  Some PGP clients might only support this version.

- The advanced method uses an `openpgpkey` subdomain.

https://tools.ietf.org/html/draft-koch-openpgp-webkey-service

The public keys are expected to be in the server configuration in a
"pgp" object list along with the user's uid.

```
pgp:
  - uid: marie
    ascii_armored_public_key: |
      -----BEGIN PGP PUBLIC KEY BLOCK-----

      […]
      -----END PGP PUBLIC KEY BLOCK-----
```

The server's `gpg` is used to determine the WKD hash for each key, which
is then used to name the published files.