### PR TITLE
Move 'colorize' package to 'bootstrap' role

### DIFF
--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -25,3 +25,6 @@ base_packages:
   - systemd-timesyncd
   - unattended-upgrades
   - xkcdpass
+
+recommended_packages:
+  - colorize

--- a/roles/bootstrap/tasks/check/packages.yml
+++ b/roles/bootstrap/tasks/check/packages.yml
@@ -11,3 +11,11 @@
   loop_control:
     loop_var: pkg
   tags: apt
+
+- name: Check that all packages are installed
+  ansible.builtin.assert:
+    that: ansible_facts.packages[pkg] is defined
+  loop: '{{ recommended_packages }}'
+  loop_control:
+    loop_var: pkg
+  tags: apt

--- a/roles/bootstrap/tasks/install/packages.yml
+++ b/roles/bootstrap/tasks/install/packages.yml
@@ -4,3 +4,8 @@
   ansible.builtin.apt:
     name: '{{ base_packages }}'
     state: present
+
+- name: Install the packages absolutely required
+  ansible.builtin.apt:
+    name: '{{ recommended_packages }}'
+    state: present

--- a/roles/certificates/vars/main.yml
+++ b/roles/certificates/vars/main.yml
@@ -2,7 +2,6 @@
 
 cert_packages:
   - ca-certificates
-  - colorize
   - gnutls-bin
   - jq
   - lego


### PR DESCRIPTION
Due to role ordering in 'config/defaults/version-*.yml' it will always absent, as 'firewall' runs before 'certificates'.